### PR TITLE
Support overlapped copying of homogenous numeric vectors

### DIFF
--- a/runtime/Include/bigloo_vector.h
+++ b/runtime/Include/bigloo_vector.h
@@ -295,27 +295,27 @@ BGL_RUNTIME_DECL obj_t alloc_hvector( int, int, int );
    alloc_hvector( len, sizeof( double ), F64VECTOR_TYPE )
 
 #define BGL_SU8VECTOR_COPY( target, tstart, source, sstart, ssend ) \
-   memcpy( (void *)&BGL_S8VREF( target, tstart ), (void *)&BGL_S8VREF( source, sstart ), \
+   memmove( (void *)&BGL_S8VREF( target, tstart ), (void *)&BGL_S8VREF( source, sstart ), \
 	   (ssend - sstart) )
    
 #define BGL_SU16VECTOR_COPY( target, tstart, source, sstart, ssend ) \
-   memcpy( (void *)&BGL_S16VREF( target, tstart ), (void *)&BGL_S16VREF( source, sstart ), \
+   memmove( (void *)&BGL_S16VREF( target, tstart ), (void *)&BGL_S16VREF( source, sstart ), \
       (ssend - sstart) * 2 )
    
 #define BGL_SU32VECTOR_COPY( target, tstart, source, sstart, ssend ) \
-   memcpy( (void *)&BGL_S32VREF( target, tstart ), (void *)&BGL_S32VREF( source, sstart ), \
+   memmove( (void *)&BGL_S32VREF( target, tstart ), (void *)&BGL_S32VREF( source, sstart ), \
       (ssend - sstart) * 4 )
    
 #define BGL_SU64VECTOR_COPY( target, tstart, source, sstart, ssend ) \
-   memcpy( (void *)&BGL_S64VREF( target, tstart ), (void *)&BGL_S64VREF( source, sstart ), \
+   memmove( (void *)&BGL_S64VREF( target, tstart ), (void *)&BGL_S64VREF( source, sstart ), \
       (ssend - sstart) * 8 )
    
 #define BGL_F32VECTOR_COPY( target, tstart, source, sstart, ssend ) \
-   memcpy( (void *)&BGL_F32VREF( target, tstart ), (void *)&BGL_F32VREF( source, sstart ), \
+   memmove( (void *)&BGL_F32VREF( target, tstart ), (void *)&BGL_F32VREF( source, sstart ), \
       (ssend - sstart) * 4 )
    
 #define BGL_F64VECTOR_COPY( target, tstart, source, sstart, ssend ) \
-   memcpy( (void *)&BGL_F64VREF( target, tstart ), (void *)&BGL_F64VREF( source, sstart ), \
+   memmove( (void *)&BGL_F64VREF( target, tstart ), (void *)&BGL_F64VREF( source, sstart ), \
       (ssend - sstart) * 8 )
    
 

--- a/runtime/Jlib/foreign.java
+++ b/runtime/Jlib/foreign.java
@@ -4106,43 +4106,103 @@ public final class foreign
    
    public static void BGL_SU8VECTOR_COPY(u8vector t, int ts, u8vector s, int ss, int se ) {
       int len = se - ss;
-      for( int i = 0; i < len; i++ ) {
-	 t.objs[ ts + i ] = s.objs[ ss + i ];
+      boolean forward = true;
+      if (t == s) {
+          forward = !((ss < ts) && (ts < (ss + len)));
+      }
+      if (forward) {
+          for( int i = 0; i < len; i++ ) {
+              t.objs[ ts + i ] = s.objs[ ss + i ];
+          }
+      } else {
+          for( int i = len-1; i >= 0; i-- ) {
+              t.objs[ ts + i ] = s.objs[ ss + i ];
+          }
       }
    }
    
    public static void BGL_SU16VECTOR_COPY(u16vector t, int ts, u16vector s, int ss, int se ) {
       int len = se - ss;
-      for( int i = 0; i < len; i++ ) {
-	 t.objs[ ts + i ] = s.objs[ ss + i ];
+       boolean forward = true;
+      if (t == s) {
+          forward = !((ss < ts) && (ts < (ss + len)));
+      }
+      if (forward) {
+          for( int i = 0; i < len; i++ ) {
+              t.objs[ ts + i ] = s.objs[ ss + i ];
+          }
+      } else {
+          for( int i = len-1; i >= 0; i-- ) {
+              t.objs[ ts + i ] = s.objs[ ss + i ];
+          }
       }
    }
    
    public static void BGL_SU32VECTOR_COPY(u32vector t, int ts, u32vector s, int ss, int se ) {
       int len = se - ss;
-      for( int i = 0; i < len; i++ ) {
-	 t.objs[ ts + i ] = s.objs[ ss + i ];
+       boolean forward = true;
+      if (t == s) {
+          forward = !((ss < ts) && (ts < (ss + len)));
+      }
+      if (forward) {
+          for( int i = 0; i < len; i++ ) {
+              t.objs[ ts + i ] = s.objs[ ss + i ];
+          }
+      } else {
+          for( int i = len-1; i >= 0; i-- ) {
+              t.objs[ ts + i ] = s.objs[ ss + i ];
+          }
       }
    }
    
    public static void BGL_SU64VECTOR_COPY(u64vector t, int ts, u64vector s, int ss, int se ) {
       int len = se - ss;
-      for( int i = 0; i < len; i++ ) {
-	 t.objs[ ts + i ] = s.objs[ ss + i ];
+       boolean forward = true;
+      if (t == s) {
+          forward = !((ss < ts) && (ts < (ss + len)));
+      }
+      if (forward) {
+          for( int i = 0; i < len; i++ ) {
+              t.objs[ ts + i ] = s.objs[ ss + i ];
+          }
+      } else {
+          for( int i = len-1; i >= 0; i-- ) {
+              t.objs[ ts + i ] = s.objs[ ss + i ];
+          }
       }
    }
    
    public static void BGL_F32VECTOR_COPY(u32vector t, int ts, u32vector s, int ss, int se ) {
       int len = se - ss;
-      for( int i = 0; i < len; i++ ) {
-	 t.objs[ ts + i ] = s.objs[ ss + i ];
+       boolean forward = true;
+      if (t == s) {
+          forward = !((ss < ts) && (ts < (ss + len)));
+      }
+      if (forward) {
+          for( int i = 0; i < len; i++ ) {
+              t.objs[ ts + i ] = s.objs[ ss + i ];
+          }
+      } else {
+          for( int i = len-1; i >= 0; i-- ) {
+              t.objs[ ts + i ] = s.objs[ ss + i ];
+          }
       }
    }
    
    public static void BGL_F64VECTOR_COPY(u64vector t, int ts, u64vector s, int ss, int se ) {
       int len = se - ss;
-      for( int i = 0; i < len; i++ ) {
-	 t.objs[ ts + i ] = s.objs[ ss + i ];
+       boolean forward = true;
+      if (t == s) {
+          forward = !((ss < ts) && (ts < (ss + len)));
+      }
+      if (forward) {
+          for( int i = 0; i < len; i++ ) {
+              t.objs[ ts + i ] = s.objs[ ss + i ];
+          }
+      } else {
+          for( int i = len-1; i >= 0; i-- ) {
+              t.objs[ ts + i ] = s.objs[ ss + i ];
+          }
       }
    }
    


### PR DESCRIPTION
Modify the implementation of homogenous numeric <type>vector-copy! to support overlapped copying. This allows the copying of potentially overlapping regions in the same vector. 