### PR TITLE
Support overlapped copying of normal vectors

### DIFF
--- a/recette/vector.scm
+++ b/recette/vector.scm
@@ -97,4 +97,12 @@
    (let* ((v (vector 1 2 3))
 	  (v2 (vector 0)))
       (vector-copy! v2 0 v 1 2)
-      (test "vector-copy!" v2 '#(2))))
+      (test "vector-copy!" v2 '#(2)))
+   (let ((v (vector 1 2 3 4 5 6 7 8)))
+      (vector-copy! v 4 v 0 4)
+      (test "vector-copy! with from and to being the same vector" v '#(1 2 3 4 1 2 3 4))
+      (vector-copy! v 2 v 0 6)
+      (test "vector-copy! with from and to being the same vector and the range is overlapped"
+         v '#(1 2 1 2 3 4 1 2)))
+
+   )

--- a/runtime/Ieee/vector.scm
+++ b/runtime/Ieee/vector.scm
@@ -281,13 +281,22 @@
 ;*---------------------------------------------------------------------*/
 (define (vector-copy! target tstart source
 		      #!optional (sstart 0) (send (vector-length source)))
-   (let ((end (minfx send (vector-length source)))
-	 (tend (vector-length target)))
-      (let loop ((i sstart)
-		 (j tstart))
-	 (when (and (<fx i end) (<fx j tend))
-	    (vector-set-ur! target j (vector-ref-ur source i))
-	    (loop (+fx i 1) (+fx j 1))))))
+   (let* ((end (minfx send (vector-length source)))
+          (count (-fx end sstart))
+          (tend (minfx (+fx tstart count) (vector-length target))))
+      (if (and (eq? target source)
+               (<fx sstart tstart)
+               (<fx tstart (+fx sstart (-fx send sstart))))
+          (let loop ((i  (-fx end 1))
+                     (j (-fx tend 1)))
+             (when (and (>=fx i sstart) (>=fx j tstart))
+                (vector-set-ur! target j (vector-ref-ur source i))
+                (loop (-fx i 1) (-fx j 1))))
+          (let loop ((i sstart)
+                     (j tstart))
+             (when (and (<fx i end) (<fx j tend))
+                (vector-set-ur! target j (vector-ref-ur source i))
+                (loop (+fx i 1) (+fx j 1)))))))
 
 ;*---------------------------------------------------------------------*/
 ;*    vector-append ...                                                */


### PR DESCRIPTION
It would stand to reason that if we support overlapped copy for homogenous vectors we should do so for normal vectors.