### PR TITLE
Enable jvm build of csv and improve performance of csv parsing

### DIFF
--- a/api/csv/Makefile
+++ b/api/csv/Makefile
@@ -33,7 +33,7 @@ POPULATION = Makefile README
 all: build
 boot: build
 
-build: build-c
+build: build-c build-jvm
 
 c: build-c
 jvm: build-jvm
@@ -46,7 +46,10 @@ build-c:
           fi
 
 build-jvm:
-	@ echo "CSV .jvm: Not implemented";
+	@ if [ "$(JVMBACKEND)" = "yes" ]; then \
+	    echo "[0m[1;31m>>> JVM[0m";  \
+	    (cd src && $(MAKE) build-jvm); \
+          fi
 
 build-dotnet:
 	@ echo "CSV .net: Not implemented";
@@ -90,8 +93,12 @@ install: api-install-init
 	    $(MAKE) api-install-c; \
           fi
 
+	@ if [ "$(JVMBACKEND)" = "yes" ]; then \
+	    $(MAKE) api-install-jvm; \
+          fi
 uninstall: api-uninstall-init \
-           api-uninstall-c
+           api-uninstall-c \
+	   api-uninstall-jvm
 
 #*---------------------------------------------------------------------*/
 #*    distrib                                                          */

--- a/api/csv/examples/Makefile
+++ b/api/csv/examples/Makefile
@@ -23,7 +23,7 @@ BCFLAGS =
 #*---------------------------------------------------------------------*/
 #*    Sources                                                          */
 #*---------------------------------------------------------------------*/
-SOURCES = gflu
+SOURCES = gflu gflu-jvm
 
 #*---------------------------------------------------------------------*/
 #*    All objects and sources                                          */
@@ -38,13 +38,16 @@ all: $(SOURCES)
 gflu: gflu.o
 	$(BIGLOO) $(EFLAGS) $(BFLAGS) $< -o $@$(EXE_SUFFIX)
 
+gflu-jvm : gflu.class
+	$(BIGLOO) -jvm $(EFLAGS) $(BFLAGS) $< -o $@$(SCRIPTEXTENSION)
+
 pop:
 	@ echo $(POPULATION:%=csv/examples/%)
 
 clean:
 	@- $(RM) -f *~ '#*#' core
-	@- $(RM) -f *.escm *.ast gflu$(EXE_SUFFIX)
-	@- $(RM) -f $(SOURCES:%=%$(EXE_SUFFIX)) $(SOURCES:%=%.o)
+	@- $(RM) -f *.escm *.ast gflu$(EXE_SUFFIX) gflu-jvm$(SCRIPTEXTENSION)
+	@- $(RM) -f $(SOURCES:%=%$(EXE_SUFFIX)) $(SOURCES:%=%.o) $(SOURCES:%=%.class)
 
 distclean: clean
 

--- a/api/csv/recette/Makefile
+++ b/api/csv/recette/Makefile
@@ -33,15 +33,13 @@ POPULATION	= recette.scm Makefile
 #*---------------------------------------------------------------------*/
 #*    the goals.                                                       */
 #*---------------------------------------------------------------------*/
-all: c # jvm dotnet
+all: c jvm #dotnet
 
 c: recette$(EXE_SUFFIX)
 recette$(EXE_SUFFIX): recette.o
 	$(BIGLOO) $(EFLAGS) $(BFLAGS) recette.o -o recette$(EXE_SUFFIX)
 
 jvm: 
-
-jvm.not-implemented:
 	@ if [ "$(JVMBACKEND)" = "yes" ]; then \
              $(MAKE) recette-jvm$(SCRIPTEXTENSION); \
 	  fi

--- a/api/csv/recette/recette.scm
+++ b/api/csv/recette/recette.scm
@@ -155,8 +155,8 @@
 	 (close-input-port in)))
    :result (lambda (v)
 	      (if (eq? v 'result)
-		  '("")
-		  (csv-record=? v '("")))))
+		  '()
+		  (csv-record=? v '()))))
 
 (define-test empty
    (let* ((test-string "")

--- a/api/csv/src/Makefile
+++ b/api/csv/src/Makefile
@@ -104,12 +104,16 @@ all:
 	@ if [ "$(NATIVEBACKEND)" = "yes" ]; then \
              $(MAKE) build-c; \
 	  fi
+		@ if [ "$(JVMBACKEND)" = "yes" ]; then \
+             $(MAKE) build-jvm; \
+	  fi
+
 
 c: build-c
 build-c: api-c
 
 jvm: build-jvm
-build-jvm:
+build-jvm: api-jvm
 
 $(MISC_SRC_DIR)/$(API).init: $(MISC_SRC_DIR)/$(API).init.in
 	@ echo "*** ERROR: $@ is out of date (older than $?)"

--- a/runtime/Jlib/input_socket_port.java
+++ b/runtime/Jlib/input_socket_port.java
@@ -98,11 +98,8 @@ public class input_socket_port extends input_port {
 
       // FIX Dustin DeWeese" <dustin.deweese gmail.com> Feb 2006.
       // final int nbread = in.read( buffer, bufpose-1, (a < size ? a : size) );
-      System.out.println( "bufpose=" + bufpose + " size=" + size + " len="
-			+ buffer.length );
       final int nbread = in.read( buffer, bufpose, size );
-      System.out.println( "nread=" + nbread );
-
+     
       if (nbread == -1)
 	 eof = true;
       else


### PR DESCRIPTION
It was determined that we are unnecessarily reallocating parser
state for each line we read. Since the parsing is simple, we
just replaces Bigloo's built-in lalr parsing facility with
a hand-coded one. This eliminated the allocation on every
line read and improved performance.

Note: There is one change in semantics. The old parser would
return a single element list consisting of an empty string when
parsing newline only line. It now returns an empty list. In my
mind, this is an improvement, the other behavior could be confusing.
Was there no fields or a single empty field.