### PR TITLE
Add the mmap->bstring procedure

### DIFF
--- a/recette/mmap.scm
+++ b/recette/mmap.scm
@@ -64,5 +64,8 @@
       (test "mmap-put-string!.1" (mmap-get-string mm 9) s)
       (test "mmap-read-position.5" (mmap-read-position mm) #e29)
       (test "mmap-write-position.5" (mmap-write-position mm) #e29)
-      (test "close-mmap" (close-mmap mm) #t)))
+      (test "close-mmap" (close-mmap mm) #t)
+       (let ((test-str (make-string 16 #a000))) (test "mmap->bstring"
+                     (mmap->bstring (string->mmap test-str))
+                     test-str))))
       

--- a/runtime/Ieee/string.scm
+++ b/runtime/Ieee/string.scm
@@ -39,7 +39,7 @@
    (extern  (macro $string?::bool (::obj) "STRINGP")
 	    ($make-string::bstring (::long ::uchar) "make_string")
 	    ($make-string/wo-fill::bstring (::long) "make_string_sans_fill")
-	    
+	    ($string->bstring-len::bstring (str::string len::int) "string_to_bstring_len")
 	    (macro $string-length::long (::bstring) "STRING_LENGTH")
 	    (macro $string-ref::uchar (::bstring ::long) "STRING_REF")
 	    (macro $string-set!::obj (::bstring ::long ::uchar) "STRING_SET")
@@ -88,8 +88,11 @@
 	       (method static $string?::bool (::obj)
 		       "STRINGP")
 	       (method static $make-string::bstring (::long ::uchar)
-		       "make_string")
-	       
+                  "make_string")
+
+               (method static $string->bstring-len::bstring (::string ::long)
+                  "string_to_bstring_len")
+	   
 	       (method static $string-length::long (::bstring)
 		       "STRING_LENGTH")
 	       

--- a/runtime/Jlib/foreign.java
+++ b/runtime/Jlib/foreign.java
@@ -2547,6 +2547,11 @@ public final class foreign
 	 return o;
       }
 
+    public static byte[] string_to_bstring_len(byte[] o, int len)
+      {
+         return o;
+      }
+
    public static byte[] BSTRING_TO_STRING(byte[]o)
       {
 	 return o;

--- a/runtime/Jlib/foreign.java
+++ b/runtime/Jlib/foreign.java
@@ -7511,7 +7511,11 @@ public final class foreign
    }
 
    public static byte[] bgl_mmap_to_string( mmap m ) {
-      return m.map.array();
+      if (m instanceof mmaps) {
+         return m.name;
+      } else {
+         return m.map.array();
+      }
    }
 
    public static Object bgl_close_mmap( mmap o ) {

--- a/runtime/Llib/mmap.scm
+++ b/runtime/Llib/mmap.scm
@@ -91,6 +91,7 @@
 	    (open-mmap::mmap ::bstring #!key (read #t) (write #t))
 	    (string->mmap::mmap ::bstring #!key (read #t) (write #t))
 	    (inline mmap->string::string ::mmap)
+            (inline mmap->bstring::bstring ::mmap)
 	    (inline close-mmap ::mmap)
 	    (inline mmap-length::elong ::mmap)
 	    (inline mmap-read-position::elong ::mmap)
@@ -131,6 +132,13 @@
 ;*---------------------------------------------------------------------*/
 (define-inline (mmap->string::string mmap::mmap)
    ($mmap->string mmap))
+
+;*---------------------------------------------------------------------*/
+;*    mmap->bstring ...                                                 */
+;*---------------------------------------------------------------------*/
+(define-inline (mmap->bstring::bstring mmap::mmap)
+   (let ((len::int  (elong->fixnum ($mmap-length mmap))))
+      ($string->bstring-len ($mmap->string mmap) len)))
 
 ;*---------------------------------------------------------------------*/
 ;*    close-mmap ...                                                   */


### PR DESCRIPTION
The mmap->bstring procedure properly handles embedded null characters
when converting a mmap to a bstring. mmap->string fails in this
regard, since it returns a c-string which when converted to a bstring
takes the first null character to be the end-of-string.