### PR TITLE
Fix bug resulting in blank/empty csv fields being elided

### DIFF
--- a/api/csv/recette/recette.scm
+++ b/api/csv/recette/recette.scm
@@ -370,5 +370,16 @@
 		  '("dog " " cat")
 		  (csv-record=? v '("dog " " cat")))))
 
+(define-test empty-fields
+   (let* ((test-string "dog,,,cat")
+	  (in (open-input-string test-string)))
+      (unwind-protect
+	 (read-csv-record in)
+	 (close-input-port in)))
+   :result (lambda (v)
+	      (if (eq? v 'result)
+		  '("dog" "" "" "cat")
+		  (csv-record=? v '("dog" "" ""  "cat")))))
+
 
 

--- a/api/csv/src/Llib/csv.scm
+++ b/api/csv/src/Llib/csv.scm
@@ -86,7 +86,11 @@
             ((eq? token 'separator)
              (loop (read/rp lexer in)
                 'separator
-                res))
+                ;; make sure we include blank/empty fields
+                (if (eq? last-token 'separator)
+                    (cons "" res)
+                    res)
+                ))
             (else
              (loop (read/rp lexer in)
                 'text


### PR DESCRIPTION
For example "dog,,cat" would result in the list ("dog" "cat") instead
of the list ("dog" "" "cat")