### PR TITLE
add missing emacs26 target

### DIFF
--- a/bmacs/Makefile
+++ b/bmacs/Makefile
@@ -116,7 +116,7 @@ POPULATION	= Makefile README $(EMACS_SOURCES) $(OLD_SOURCES) \
 #*---------------------------------------------------------------------*/
 all: $(EMACSBRAND)
 
-emacs22 emacs23 emacs24 emacs25:
+emacs22 emacs23 emacs24 emacs25 emacs26:
 	(expr=load-path; \
           for p in . $(LOADPATH); do \
              expr="(cons \"../$$p\" (cons \"$$p\" $$expr))"; \

--- a/bmacs/Makefile
+++ b/bmacs/Makefile
@@ -181,6 +181,7 @@ install.emacs22: doinstall
 install.emacs23: doinstall
 install.emacs24: doinstall
 install.emacs25: doinstall
+install.emacs26: doinstall
 install.xemacs: doinstall
 
 install.generic:


### PR DESCRIPTION
Sorry, I missed the addition of the emacs26 target when I submitted the original change.