### PR TITLE
Fix typo that prevented using /bigloo as build dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ boot-c: checkgmake
 	if [ "$(UNISTRINGCUSTOM)" = "yes" ]; then \
 	  $(MAKE) -C libunistring boot; \
         fi
-	if [ -x $(BGLBUILBINDIR)/bigloo ]; then \
+	if [ -x $(BGLBUILDBINDIR)/bigloo ]; then \
 	  $(MAKE) -C runtime .afile && \
 	  $(MAKE) -C runtime heap && \
 	  $(MAKE) -C runtime boot && \


### PR DESCRIPTION
Sven Hartrumpf spotted the problem. Discussed today on the bigloo mailing list.