### PR TITLE
Fix warnings about non-void functions with no return statement.

### DIFF
--- a/api/flac/src/Clib/bglflac.c
+++ b/api/flac/src/Clib/bglflac.c
@@ -122,6 +122,7 @@ int bgl_flac_dump( char *l, unsigned char *s, int o, int sz ) {
 
    fprintf( stderr, "\n" );
    fflush( stderr );
+   return 0;
 }
 
 /*---------------------------------------------------------------------*/

--- a/api/libuv/src/Clib/bgluv.c
+++ b/api/libuv/src/Clib/bgluv.c
@@ -2020,6 +2020,8 @@ string_array_to_vector( char *array[] ) {
    for( i = 0, runner = array; i < len; i++, runner++ ) {
       VECTOR_SET( res, i, string_to_bstring( *runner ) );
    }
+
+   return res;
 }
 
 /*---------------------------------------------------------------------*/

--- a/api/phidget/src/Clib/bglphidget.c
+++ b/api/phidget/src/Clib/bglphidget.c
@@ -1647,6 +1647,7 @@ bgl_phidget_encoder_add_event_listener( CPhidgetEncoderHandle id, char *event, o
       return CPhidgetEncoder_set_OnIndex_Handler(
 	 id, &bgl_encoderindex_handler, hdl );
    }
+   return -1;
 }
 
 /*---------------------------------------------------------------------*/

--- a/api/ssl/src/C/bglssl.c
+++ b/api/ssl/src/C/bglssl.c
@@ -1518,6 +1518,7 @@ bgl_ssl_connection_close( ssl_connection ssl ) {
    SSL *_ssl = CCON( ssl )->BgL_z42nativez42;
 
    SSL_free( _ssl );
+   return 0;
 }
 
 /*---------------------------------------------------------------------*/
@@ -2503,6 +2504,7 @@ unsupported:
 BGL_RUNTIME_DEF obj_t
 bgl_ssl_ctx_close( secure_context sc ) {
    SSL_CTX_free( CSC( sc )->BgL_z42nativez42 );
+   return BNIL;
 }
    
 /*---------------------------------------------------------------------*/

--- a/runtime/Clib/cports.c
+++ b/runtime/Clib/cports.c
@@ -1817,11 +1817,13 @@ BGL_RUNTIME_DEF obj_t
 bgl_input_port_seek( obj_t port, long pos ) {
    if( INPUT_PORT( port ).sysseek ) {
       INPUT_PORT( port ).sysseek( port, pos );
+      return port;
    } else {
       C_SYSTEM_FAILURE( BGL_IO_PORT_ERROR,
 			"set-input-port-position!",
 			"input-port does not support seeking",
 			port );
+      return 0;
    }
 }
 

--- a/runtime/Clib/crgc.c
+++ b/runtime/Clib/crgc.c
@@ -847,7 +847,7 @@ llong:
 /*    int                                                              */
 /*    rgc_debug_port ...                                               */
 /*---------------------------------------------------------------------*/
-int rgc_debug_port( obj_t port, char *msg ) {
+void rgc_debug_port( obj_t port, char *msg ) {
    long matchstart = INPUT_PORT( port ).matchstart;
    long matchstop = INPUT_PORT( port ).matchstop;
    long forward = INPUT_PORT( port ).forward;


### PR DESCRIPTION
Note that in the libuv case, a vector is created and then leaked, since it is not returned.  The other cases are probably innocuous, but fixing them eliminates some compiler warnings.