### PR TITLE
Get pa_strerror prototype for inline function pulseaudio-simple-flush

### DIFF
--- a/api/flac/src/Llib/flac_padec.scm
+++ b/api/flac/src/Llib/flac_padec.scm
@@ -25,6 +25,11 @@
    
    (static (class flacpadec::flacdec))
    
+   ;;; Get pa_strerror prototype for inline function pulseaudio-simple-flush
+   (cond-expand
+     ((library pulseaudio)
+      (extern (include "pulse/error.h"))))
+   
    (cond-expand
       ((library pulseaudio)
        (export (class flac-pulseaudiodecoder::flacmusicdecoder)))))


### PR DESCRIPTION
This is the second pull request to make declarations and definitions match.  In this case, the problem is that api/flac/src/Llib/flac_padec.scm calls pulseaudio-simple-flush.  That is an inline function.  It calls pa_strerror, but not prototype of pa_strerror is visible in flac_padec.scm.  This commit includes the necessary header to get such a prototype.

If you want me to add the `(extern ...)` clause to one of the existing `(cond-expand ...)` clauses instead, let me know.