### PR TITLE
Provide prototypes for C avahi functions

### DIFF
--- a/api/avahi/src/Clib/bavahi.h
+++ b/api/avahi/src/Clib/bavahi.h
@@ -1,0 +1,46 @@
+/*=====================================================================*/
+/*    serrano/prgm/project/bigloo/api/avahi/src/Clib/bavahi.h          */
+/*    -------------------------------------------------------------    */
+/*    Author      :  Manuel Serrano                                    */
+/*    Creation    :  Wed Oct 14 12:42:13 2020                          */
+/*    Last change :  Wed Oct 14 12:42:13 2020 (jjames)                 */
+/*    Copyright   :  2020 Manuel Serrano                               */
+/*    -------------------------------------------------------------    */
+/*    External declarations for the Bigloo avahi binding               */
+/*=====================================================================*/
+
+/* Forward references */
+struct BgL_avahizd2simplezd2pollz00_bgl;
+struct BgL_avahizd2threadedzd2pollz00_bgl;
+struct BgL_avahizd2clientzd2_bgl;
+struct BgL_avahizd2entryzd2groupz00_bgl;
+struct BgL_avahizd2servicezd2browserz00_bgl;
+struct BgL_avahizd2servicezd2typezd2browserzd2_bgl;
+struct BgL_avahizd2domainzd2browserz00_bgl;
+struct BgL_avahizd2servicezd2resolverz00_bgl;
+
+extern void bgl_avahi_simple_poll_new( struct BgL_avahizd2simplezd2pollz00_bgl * );
+extern void bgl_avahi_simple_poll_timeout( AvahiSimplePoll *, long, obj_t );
+extern void bgl_avahi_simple_poll_close( struct BgL_avahizd2simplezd2pollz00_bgl * );
+
+extern void bgl_avahi_threaded_poll_new( struct BgL_avahizd2threadedzd2pollz00_bgl * );
+extern void bgl_avahi_threaded_poll_timeout( AvahiThreadedPoll *, long, obj_t );
+extern void bgl_avahi_threaded_poll_close( struct BgL_avahizd2threadedzd2pollz00_bgl * );
+
+extern void bgl_avahi_client_new( struct BgL_avahizd2clientzd2_bgl * );
+extern void bgl_avahi_client_close( struct BgL_avahizd2clientzd2_bgl * );
+
+extern void bgl_avahi_entry_group_new( struct BgL_avahizd2entryzd2groupz00_bgl * );
+extern void bgl_avahi_entry_group_close( struct BgL_avahizd2entryzd2groupz00_bgl * );
+
+extern void bgl_avahi_service_browser_new( struct BgL_avahizd2servicezd2browserz00_bgl * );
+extern void bgl_avahi_service_browser_close( struct BgL_avahizd2servicezd2browserz00_bgl * );
+
+extern void bgl_avahi_service_type_browser_new( struct BgL_avahizd2servicezd2typezd2browserzd2_bgl * );
+extern void bgl_avahi_service_type_browser_close( struct BgL_avahizd2servicezd2typezd2browserzd2_bgl * );
+
+extern void bgl_avahi_domain_browser_new( struct BgL_avahizd2domainzd2browserz00_bgl *, AvahiDomainBrowserType );
+extern void bgl_avahi_domain_browser_close( struct BgL_avahizd2domainzd2browserz00_bgl * );
+
+extern void bgl_avahi_service_resolver_new( struct BgL_avahizd2servicezd2resolverz00_bgl * );
+extern void bgl_avahi_service_resolver_close( struct BgL_avahizd2servicezd2resolverz00_bgl * );

--- a/api/avahi/src/Clib/bglavahi.c
+++ b/api/avahi/src/Clib/bglavahi.c
@@ -22,6 +22,7 @@
 #include <avahi-common/timeval.h>
 
 #include "bglavahi.h"
+#include "bavahi.h"
 
 /*---------------------------------------------------------------------*/
 /*    Imports                                                          */

--- a/api/avahi/src/Llib/avahi.sch
+++ b/api/avahi/src/Llib/avahi.sch
@@ -21,6 +21,7 @@
       (include "avahi-common/thread-watch.h")
       (include "avahi-common/error.h")
       (include "avahi-common/alternative.h")
+      (include "bavahi.h")
 
       ;; misc
       (macro $avahi-strerror::string


### PR DESCRIPTION
This is the third pull request to make declarations and definitions match.  I struggled with this one.  Types defined in the Scheme code are used in the parameter lists of C functions that are called from Scheme.  This is the solution that I came up with, but it is kind of ugly.  I'm sure there is a better solution, but I am not sufficiently conversant with bigloo to know what it is.