### PR TITLE
Correct initialization of empty AvahiStringList

### DIFF
--- a/api/avahi/src/Clib/bglavahi.c
+++ b/api/avahi/src/Clib/bglavahi.c
@@ -482,7 +482,7 @@ AvahiStringList *
 bgl_avahi_list_to_string_list( obj_t p ) {
    // MS: 28 feb 2017
    // AvahiStringList *l = avahi_string_list_new( "", NULL );
-   AvahiStringList *l = avahi_string_list_new( 0L );
+   AvahiStringList *l = NULL;
 
    while( PAIRP( p ) ) {
       l = avahi_string_list_add( l, BSTRING_TO_STRING( CAR( p ) ) );


### PR DESCRIPTION
An empty `AvahiStringList` is represented by `NULL`, as described in the API documentation: https://www.avahi.org/doxygen/html/struct_avahi_string_list.html.  The `avahi_string_list_new` function is for use when the list is to be initialized with 1 or more strings.