### PR TITLE
Correct 2 gcc warnings about format specifiers

### DIFF
--- a/bde/bmem/lib/gchook.c
+++ b/bde/bmem/lib/gchook.c
@@ -62,7 +62,7 @@ GC_collect_hook( int heapsz, long livesz ) {
 		  gc_alloc_size / 1024,
 		  heapsz / 1024,
 		  livesz / 1024,
-		  lf );
+		  bgl_debug_trace_top_name( 0 ) );
       }
    }
       
@@ -104,7 +104,7 @@ GC_dump_gc_sexp( gc_info_t *i, FILE *f ) {
 /*---------------------------------------------------------------------*/
 static void
 GC_dump_gc_json( gc_info_t *i, FILE *f ) {
-   fprintf( f, "    { \"number\": %lu, \"alloc\": %lu, \"heap\": %lu, \"live\": %lu, \"lastfun\": %s, \"time\": %ld }",
+   fprintf( f, "    { \"number\": %lu, \"alloc\": %lu, \"heap\": %lu, \"live\": %lu, \"lastfun\": %s, \"time\": %lld }",
 	    i->number,
 	    BMEMSIZE( i->alloc_size ),
 	    i->heap_size,


### PR DESCRIPTION
This commit fixes 2 gcc -Wformat warnings.  In the first case, the result of `bgl_debug_trace_top(0)` is passed to printf as a string; I believe the result of `bgl_debug_trace_top_name(0)` should be passed instead.  In the second case, i->time has type `long long`, which does not match the `%ld` format specifier.