### PR TITLE
use the destination filename as soname when provided when linking shared libraries

### DIFF
--- a/comptime/Cc/ld.scm
+++ b/comptime/Cc/ld.scm
@@ -158,11 +158,14 @@
 		   (delete-duplicates *cflags-rpath*))))))
 
    (define (default-soname files)
-      (let ((name (if (pair? files) (car files) "out")))
+      (let ((name (cond
+                     ((string? *dest*) *dest*)
+                     ((pair? files) (car files))
+                     (else "out"))))
 	 (string-append (prefix
-			   (if (string? (car files))
-			       (car files)
-			       (symbol->string (car files))))
+			   (if (string? name)
+			       name
+			       (symbol->string name)))
 	    "."
 	    (bigloo-config 'shared-lib-suffix))))
 


### PR DESCRIPTION
For example

bigloo -y -o libtest-1.0.so main.o

results in the soname being set to libtest-1.0.so instead of main.so
as previously.