### PR TITLE
Address invalid class name issues with new versions of the JVM

### DIFF
--- a/bde/jfile/jfile.scm
+++ b/bde/jfile/jfile.scm
@@ -129,7 +129,18 @@
 ;*    make-package-name ...                                            */
 ;*---------------------------------------------------------------------*/
 (define (make-package-name name)
-   (let ((name (prefix name)))
+   (let* ((base-name-sans-ext (prefix (basename name)))
+          ;; we are assuming that the directory portion does not contain
+          ;; components requiring name mangling. If this is not so, the
+          ;; jvm will complain about invalid class names. Should we
+          ;; name mangle directory components?
+          (dir-name  (dirname name))
+          (name (string-append (if (string=? dir-name ".")
+                                   ""
+                                   (string-append dir-name "/")) 
+                   (if (bigloo-need-mangling? base-name-sans-ext)
+                       (bigloo-mangle base-name-sans-ext)
+                       base-name-sans-ext))))
       (let loop ((i (-fx (string-length name) 1)))
 	 (cond
 	    ((=fx i -1)

--- a/comptime/BackEnd/jvm.scm
+++ b/comptime/BackEnd/jvm.scm
@@ -102,12 +102,12 @@
    (let ((l* (saw_jvm-compile me))
 	 (bname (cond
 		   ((eq? *pass* 'ld)
-		    (if (pair? *src-files*)
-			(addsuffix (prefix (basename (car *src-files*))))
+		    (if (symbol? (jvm-qname me))
+			(addsuffix (prefix (basename (symbol->string (jvm-qname me)))))
 			"a.class"))
 		   ((not (string? *dest*))
-		    (if (pair? *src-files*)
-			(addsuffix (prefix (basename (car *src-files*))))
+		    (if (symbol? (jvm-qname me))
+			(addsuffix (prefix (basename (symbol->string (jvm-qname me)))))
 			#f))
 		   (else
 		    (addsuffix (prefix (basename *dest*)))))))

--- a/comptime/Read/jvm.scm
+++ b/comptime/Read/jvm.scm
@@ -154,7 +154,10 @@
 	      ;; there is no specified destination so the JVM package is
 	      ;; just bigloo
 	      (let ((qt (if (string? (car *src-files*))
-			    (prefix (basename (car *src-files*)))
+			    (let ((uqtype (prefix (basename (car *src-files*)))))
+                               (if (bigloo-need-mangling? uqtype)
+                                   (bigloo-mangle uqtype)
+                                   uqtype))
 			    ".")))
 		 (add-qualified-type! *module* qt)
 		 qt))


### PR DESCRIPTION
3 changes were made to address the stricter enforcement of the
identifier rules in the JLS by newer jvms. The exact rules can be
found at
https://docs.oracle.com/javase/specs/jls/se11/html/jls-3.html#jls-3.8.

1. jfile was modified to produce mangled qualified types when the
   source file name contains identifiers not supported by the
   JLS. Note, we are currently only doing the mangling for the base
   name sans extension and not all directory components.

2. The jvm backend was modified to honor the qualified type names
   provided by jfile. Before this, the resulting class file was always
   the base name of the source file with a .class extension.

3. When no jfile information is provided, we mangle the auto-produced
   qualified name, if needed.

The changes above provide the following behavior. Assuming a source
file name test-case.scm containing a module named test-name with a
-pbase of bigloo.test, jfile will produces the .jfile below

((test-case "bigloo.test.BgL_testzd2casezd2"))

and the class file will be bigloo/test/BgL_testzd2casezd2.class.

For the same example src file when no .jfile is provided, the jvm backend will generate
a class file named BgL_testzd2casezd2.class