### PR TITLE
Add -- arg to bigloo compiler to end bigloo arg parsing for remaining args

### DIFF
--- a/comptime/Engine/interp.scm
+++ b/comptime/Engine/interp.scm
@@ -80,6 +80,9 @@
 	  (loop (cdr args) res))
 	 ((member (car args) *src-files*)
 	  (loop (cdr args) res))
+         ;; filter out the end bigloo option marker
+         ((string=? (car args) "--")
+          (loop (cdr args) res))
 	 (else
 	  (loop (cdr args) (cons (car args) res))))))
 			   

--- a/comptime/Init/parse_args.scm
+++ b/comptime/Init/parse_args.scm
@@ -1033,11 +1033,19 @@
 	   (set! *target-language* '.net))
 	  (else
 	   (error "parse-args" "Unknown target" lang))))
+
+;*--- end bigloo arg parsing  --------------------------------------*/
+      ((("--")
+        (help "--" "end bigloo arg parsing"))
+       (set! *rest-args*  (append *rest-args* (reverse! the-remaining-args)))
+       (set! the-remaining-args '()))
+
       
 ;*--- Unknown arguments -----------------------------------------------*/
       (("-?dummy")
        (set! *rest-args* (cons (string-append "-" dummy) *rest-args*)))
       
+     
 ;*--- The source file -------------------------------------------------*/
       (else
        (let ((suf (suffix else)))


### PR DESCRIPTION
This is useful when you are using the interpreter and do not want
bigloo interpreting args intended for a script. All args after
-- are ignored by bigloo. For example, the following command will pass
--help to the script instead of being recognized and handled by bigloo.

bigloo -i script.scm -- --help