### PR TITLE
handle the lib parameter of dynamic-load-sym the same as in dynamic-load

### DIFF
--- a/runtime/Llib/os.scm
+++ b/runtime/Llib/os.scm
@@ -1072,8 +1072,15 @@
 ;*    dynamic-load-symbol ...                                          */
 ;*---------------------------------------------------------------------*/
 (define (dynamic-load-symbol lib name #!optional module)
-   (let ((sym (if (string? module) (bigloo-module-mangle name module) name)))
-      ($bgl-dlsym lib name sym)))
+   (let ((sym (if (string? module) (bigloo-module-mangle name module) name))
+         (flib (cond-expand
+		  (bigloo-c
+		   (find-file/path lib *dynamic-load-path*))
+		  (bigloo-jvm
+		   lib)
+		  (else
+		   (find-file/path lib *dynamic-load-path*)))))
+      ($bgl-dlsym flib name sym)))
 
 ;*---------------------------------------------------------------------*/
 ;*    dynamic-load-symbol-get ...                                      */


### PR DESCRIPTION
dynamic-load derives the final library name used for loading by
calling find-file/path. The resulting name is used to record that the
library is loaded. dynamic-load-sym previously omitted this call
to find-file/path resulting in the function failing unless the
the absolute path to the library was used (i.e., lib = (find-file/path
lib *dynamic-load-path*)). With this change, the following will
succeed, assuming mylibrary.so is found in the *dynamic-load-path*,
where it failed in the past.

(dynamic-load "mylibrary.so" #f 'mymodule)
(define res (dynamic-load-symbol "mylibrary.so" "myprocedure"
                                 "mymodule"))