### PR TITLE
Fix gmp detection when gmplib contains spaces

### DIFF
--- a/configure
+++ b/configure
@@ -2356,7 +2356,7 @@ if [ "$gmpversion " != "no " ]; then
         gmplib=-lgmp
       fi
   
-      gmpversion=`$autoconf gmp --lib=$gmplib` || exit 1
+      gmpversion=`$autoconf gmp --lib="$gmplib"` || exit 1
     fi
   fi  
   


### PR DESCRIPTION
`gmplib` may contain multiple flags (e.g. `-L/some/dir -lgmp`) so quoting is required here.