### PR TITLE
Fix pcre2 detection failing due to missing timespec

### DIFF
--- a/autoconf/pcre2
+++ b/autoconf/pcre2
@@ -63,7 +63,6 @@ cat > $file.c <<EOF
 void match(char *data, char *pattern) {
   int count = 0;
   double elapsed;
-  struct timespec start, end;
   pcre2_code *re;
   int errorcode;
   PCRE2_SIZE erroroffset;


### PR DESCRIPTION
Using timespec requires `#include <time.h>` on some platforms, but the variables seem to be unused so I think we can remove the line entirely.