### PR TITLE
correct signature of bgl_bignum_and

### DIFF
--- a/runtime/Clib/cbignum.c
+++ b/runtime/Clib/cbignum.c
@@ -1142,7 +1142,7 @@ bgl_bignum_mask(obj_t x, long n) {
 /*    bgl_bignum_and ...                                               */
 /*---------------------------------------------------------------------*/
 BGL_RUNTIME_DEF obj_t
-bgl_bignum_and(obj_t x, long y) {
+bgl_bignum_and(obj_t x, obj_t y) {
    obj_t obj;
    mpz_t rop;
    


### PR DESCRIPTION
The second argument of bgl_bignum_and was mistakenly long instead of obj_t