### PR TITLE
Fix special handling in xml and html parsers

### DIFF
--- a/api/web/src/Llib/html.scm
+++ b/api/web/src/Llib/html.scm
@@ -32,7 +32,7 @@
 ;*    *html-special-elements* ...                                      */
 ;*---------------------------------------------------------------------*/
 (define *html-special-elements*
-   '((meta)
+   `((meta)
      (link)
      (br) (hr) (img) (input)
      (p . (a abbr acronym address big button caption del em

--- a/api/web/src/Llib/xml.scm
+++ b/api/web/src/Llib/xml.scm
@@ -128,7 +128,7 @@
 ;*---------------------------------------------------------------------*/
 ;*    special ...                                                      */
 ;*---------------------------------------------------------------------*/
-(define-struct special tag attributes body owner)
+(define-struct special tag attributes body owner pos)
 
 
 ;*---------------------------------------------------------------------*/
@@ -159,7 +159,7 @@
 		(let ((nitem (make-element (special-tag item)
 				(special-attributes item)
 				(special-body item)
-                                start-pos)))
+                                (special-pos item))))
 		   (if (memq (special-tag item) tags)
 		       (loop acc nitem)
 		       (list (make-element tag attributes (reverse! acc) start-pos) nitem))))
@@ -185,7 +185,7 @@
 	 ((pair? (cdr spec))
 	  (let ((ignore (lambda ()
 			   (read/rp xml-grammar port
-			      make-element
+			      (lambda (t a b p) (special t a b tag p))
 			      make-content
 			      make-comment
 			      make-declaration

--- a/manuals/web.texi
+++ b/manuals/web.texi
@@ -57,7 +57,7 @@ A function of 2 arguments: the comment and the start position.
 A function of 2 arguments: the declaration and the start position.
 @item @var{make-cdata} the cdata constructor.
 A function of 2 arguments: the cdata and the start position.
-@item @var{make-xml-declaration} the cdata constructor.
+@item @var{make-xml-declaration} the xml declaration constructor.
 A function of 2 arguments: the xml-declaration and the start position.
 @item @var{make-instruction} the instruction constructor.
 A function of 2 arguments: the instruction and the start position.


### PR DESCRIPTION
A bug in specials handling in xml-parse prevented html-parse from
functioning correctly. Additionally, a small error in +html-special-elements+
prevented script blocks from being parsed correctly.