### PR TITLE
Extend IPv6 support in the sockets api

### DIFF
--- a/api/ssl/src/C/bglssl.c
+++ b/api/ssl/src/C/bglssl.c
@@ -656,8 +656,8 @@ BGL_RUNTIME_DEF obj_t
 bgl_make_ssl_client_socket( obj_t hostname, int port, int ms, 
                             int protocol, obj_t cert, obj_t pkey,
                             obj_t ca_list, obj_t accepted_certs,
-			    obj_t inbuf, obj_t outbuf ) {
-   obj_t sock = bgl_make_client_socket( hostname, port, ms, inbuf, outbuf );
+			    obj_t inbuf, obj_t outbuf, obj_t domain ) {
+  obj_t sock = bgl_make_client_socket( hostname, port, ms, inbuf, outbuf, domain );
    
    return bgl_client_socket_use_ssl( sock,
 				     protocol, cert, pkey,
@@ -701,8 +701,8 @@ socket_server_enable_ssl( obj_t serv, obj_t s ) {
 BGL_RUNTIME_DEF obj_t
 bgl_make_ssl_server_socket( obj_t hostname, int port, int protocol, 
                             obj_t cert, obj_t pkey, obj_t ca_list,
-                            obj_t accepted_certs, int backlog, bool_t ipv6 ) {
-   obj_t serv = bgl_make_server_socket( hostname, port, backlog, ipv6 );
+                            obj_t accepted_certs, int backlog, obj_t domain ) {
+   obj_t serv = bgl_make_server_socket( hostname, port, backlog, domain );
    obj_t data = BNIL;
    /* data is (proto cert pkey ca_list acceptedcerts) */
    data = MAKE_PAIR( accepted_certs, data );

--- a/api/ssl/src/Java/ssl_client_socket13.java
+++ b/api/ssl/src/Java/ssl_client_socket13.java
@@ -25,7 +25,8 @@ public class ssl_client_socket extends client_socket {
 			    Object caList,
 			    Object acceptedCerts,
 			    byte[] inbuf,
-			    byte[] outbuf ) {
+			    byte[] outbuf,
+                            symbol domain) {
       super();
       
       try {

--- a/api/ssl/src/Java/ssl_client_socket15.java
+++ b/api/ssl/src/Java/ssl_client_socket15.java
@@ -39,7 +39,8 @@ public class ssl_client_socket extends client_socket {
 			    Object caList,
 			    Object acceptedCerts,
 			    byte[] inbuf,
-			    byte[] outbuf ) {
+			    byte[] outbuf,
+                            symbol domain) {
       super();
       
       try {

--- a/manuals/socket.texi
+++ b/manuals/socket.texi
@@ -55,8 +55,10 @@ The supported domains are:
 
 @itemize @bullet
 @item @code{inet}: IPv4 Internet protocols.
+@item @code{inet6}: IPv6 Internet protocols.
 @item @code{unix}: Unix sockets for local inter-process communications.
 @item @code{local}: Same as @code{unix}.
+@item @code{unspec}: uses IPv4 or IPv6 as determined by getaddrinfo.
 @end itemize
 
 If the connection cannot be established, an @code{&io-error} is raised
@@ -137,7 +139,7 @@ the distant system's idea of the time of day.}:
 @end smalllisp
 @end deffn
 
-@deffn {bigloo procedure} make-server-socket #!optional (port 0) #!key (name #f) (backlog 5)
+@deffn {bigloo procedure} make-server-socket #!optional (port 0) #!key (name #f) (backlog 5) (domain 'inet)
 @code{make-server-socket} returns a new socket object. 
 The socket will be listening on the network interface @var{name}, 
 either on the specified @var{port}, or on a port chosen by the system
@@ -147,6 +149,17 @@ be used (as returned by the name server lookup).
 
 The @var{backlog} argument specifies the size of the wait-queue used for
 accepting connections.
+
+The @var{domain} argument specifies the address family to use. The supported domains
+are:
+
+@itemize @bullet
+@item @code{inet}: IPv4 Internet protocols.
+@item @code{inet6}: IPv6 Internet protocols.
+@item @code{unix}: Unix sockets for local inter-process communications.
+@item @code{local}: Same as @code{unix}.
+@end itemize
+
 @end deffn
 
 @deffn {bigloo procedure} socket-accept socket #!key (errp #t) (inbuf #t) (outbuf #t)
@@ -320,16 +333,56 @@ consecutive connections:
 Bigloo also provides primitives dealing with @dfn{datagram} sockets, for
 use with transports such as UDP.  These are shown below:
 
-@deffn {bigloo procedure} make-datagram-server-socket @var{port}
-Return a datagram server socket bound to the loopback address on
-@var{port}, and whose address family and protocol family are those
-normally used for services on @var{port}.
+@deffn {bigloo procedure} make-datagram-client-socket hostname port #!optional broadcast (domain 'inet)
+
+return a datagram client socket connected to @var{hostname} on @var{port} whose address family is specified by @var{domain}.
+
+The supported domains
+are:
+
+@itemize @bullet
+@item @code{inet}: IPv4 Internet protocols.
+@item @code{inet6}: IPv6 Internet protocols.
+@end itemize
+
+@end deffn
+
+@deffn {bigloo procedure} make-datagram-server-socket #!optional (port 0) (domain 'inet)
+Return a datagram server socket listening on @var{port}, and whose address family is
+specified by @var{domain}. The supported domains
+are:
+
+@itemize @bullet
+@item @code{inet}: IPv4 Internet protocols.
+@item @code{inet6}: IPv6 Internet protocols.
+@end itemize
+
+
+
 @end deffn
 
 @deffn {bigloo procedure} make-datagram-unbound-socket [(domain 'inet)]
-Return an unbound datagram socket.  It may then be used in conjunction
+Return an unbound datagram socket,whose address family is
+specified by @var{domain}. The supported domains
+are:
+
+@itemize @bullet
+@item @code{inet}: IPv4 Internet protocols.
+@item @code{inet6}: IPv6 Internet protocols.
+@end itemize
+
+It may then be used in conjunction
 with @code{datagram-socket-send} and @code{datagram-socket-receive}, for
 instance send to and receive from a UDP multicast address.
+@end deffn
+
+@deffn {bigloo procedure} datagram-socket-input socket
+@deffnx {bigloo procedure} datagram-socket-output socket
+
+Returns the file port associated for reading or writing with the program 
+connected with datagram @var{socket}. If no connection has already been established,
+these functions return @code{#f}.
+
 @end deffn
 
 @deffn {bigloo procedure} datagram-socket-receive sock size

--- a/manuals/ssl.texi
+++ b/manuals/ssl.texi
@@ -46,7 +46,7 @@ Returns @code{#t} if an only if obj is a SSL socket (either client or server).
 Returns @code{#f} otherwise.
 @end deffn
 
-@deffn {SSL library procedure} make-ssl-client-socket hostname port-number #!key (buffer #t) (timeout 0) (protocol 'sslv23) (cert #f) (pkey #f) (CAs '()) (accepted-certs #f)
+@deffn {SSL library procedure} make-ssl-client-socket hostname port-number #!key (buffer #t) (timeout 0) (protocol 'sslv23) (cert #f) (pkey #f) (CAs '()) (accepted-certs #f) (domain 'inet)
 @cindex unbufferized socket port
 
 @code{make-ssl-client-socket} returns a new client socket object. This
@@ -104,6 +104,15 @@ If @var{accepted-certs} is a list, the peer (server) certificate must
 match one of the given certificates. Otherwise, an @code{&io-error} 
 will be raised.
 
+The optional @var{domain} argument specifies the protocol used by the socket.
+The supported domains are:
+
+@itemize @bullet
+@item @code{inet}: IPv4 Internet protocols.
+@item @code{inet6}: IPv6 Internet protocols.
+@item @code{unspec}: uses IPv4 or IPv6 as determined by getaddrinfo.
+@end itemize
+
 If the connection cannot be established, an @code{&io-error} is raised
 (see @ref{Errors Assertions and Traces}).
 
@@ -143,7 +152,7 @@ Returns an SSL socket built from a socket obtained by @code{make-client-socket}
 returned socket may or may not be @code{eq?} to @var{socket}.
 @end deffn
 
-@deffn {SSL library procedure} make-ssl-server-socket #!key (port 0) (name #f) (protocol 'sslv23) (cert #f) (pkey #f) (CAs '()) (accepted-certs #f)
+@deffn {SSL library procedure} make-ssl-server-socket #!key (port 0) (name #f) (protocol 'sslv23) (cert #f) (pkey #f) (CAs '()) (accepted-certs #f) (domain 'inet)
 @cindex unbufferized socket port
 
 @code{make-ssl-server-socket} returns a new server socket object which
@@ -198,6 +207,14 @@ certificate is accepted (aside from eventual certificate validation).
 If @var{accepted-certs} is a list, the peer (client) certificate must
 match one of the given certificates. Otherwise, an @code{&io-error} 
 will be raised when accepting the client socket.
+
+The optional @var{domain} argument specifies the protocol used by the socket.
+The supported domains are:
+
+@itemize @bullet
+@item @code{inet}: IPv4 Internet protocols.
+@item @code{inet6}: IPv6 Internet protocols.
+@end itemize
 
 If the connection cannot be established, an @code{&io-error} is raised
 (see @ref{Errors Assertions and Traces}).

--- a/runtime/Include/bigloo.h
+++ b/runtime/Include/bigloo.h
@@ -831,10 +831,10 @@ union scmobj {
       int stype;
       /* the close hook */
       union scmobj *chook;
-      /* socket server */
-      void *server;
       /* assocated port */
       union scmobj *port;
+      /* socket server */
+      void *server;
    } datagram_socket;
 
    /* regular expressions */
@@ -2543,8 +2543,8 @@ BGL_RUNTIME_DECL void (*bgl_gc_stop_blocking)(void);
 BGL_RUNTIME_DECL void *(*bgl_gc_do_blocking)(void (*fun)(), void *);
 #endif
    
-BGL_RUNTIME_DECL obj_t bgl_make_client_socket(obj_t, int, int, obj_t, obj_t);
-BGL_RUNTIME_DECL obj_t bgl_make_server_socket(obj_t, int, int, bool_t);
+BGL_RUNTIME_DECL obj_t bgl_make_client_socket(obj_t, int, int, obj_t, obj_t, obj_t);
+BGL_RUNTIME_DECL obj_t bgl_make_server_socket(obj_t, int, int, obj_t);
 BGL_RUNTIME_DECL obj_t bgl_socket_accept(obj_t, bool_t, obj_t, obj_t);
 BGL_RUNTIME_DECL long bgl_socket_accept_many(obj_t, bool_t, obj_t, obj_t, obj_t);
    

--- a/runtime/Jlib/datagram_client_socket.java
+++ b/runtime/Jlib/datagram_client_socket.java
@@ -28,10 +28,14 @@ public class datagram_client_socket extends datagram_socket {
    
    public datagram_client_socket( final byte[] hostname,
 				  final int port,
-				  final boolean broadcast ) {
+				  final boolean broadcast,
+                                  final symbol family) {
       super();
 
       try {
+          // FIXME
+          // java provides no way to force the address family
+          // at runtime, so we ignore for now.
 	 ip = InetAddress.getByName( new String( hostname ) );
 	 
 	 socket = new DatagramSocket();

--- a/runtime/Jlib/datagram_server_socket.java
+++ b/runtime/Jlib/datagram_server_socket.java
@@ -22,10 +22,12 @@ public class datagram_server_socket extends datagram_socket {
       super();
    }
    
-   public datagram_server_socket( final int port ) {
+    public datagram_server_socket( final int port,
+                                   final symbol family ) {
       super();
 
       try {
+         // FIXME: The address family cannot be specified.
 	 socket = new DatagramSocket( port );
 	 input = new input_datagram_port( this, port );
       } catch( final IOException e ) {

--- a/runtime/Jlib/foreign.java
+++ b/runtime/Jlib/foreign.java
@@ -5953,7 +5953,8 @@ public final class foreign
 						int port,
 						int timeo,
 						byte[] inbuf,
-						byte[] outbuf )
+						byte[] outbuf,
+                                                symbol family)
       {
 	 return new client_socket(hostname, port, inbuf, outbuf );
       }
@@ -5961,7 +5962,7 @@ public final class foreign
    public static socket bgl_make_server_socket(Object name,
 					       int port,
 					       int backlog,
-					       boolean ipv6)
+					       symbol family)
       {
 	 return new server_socket(name, port);
       }
@@ -6074,12 +6075,14 @@ public final class foreign
 
    public static datagram_socket bgl_make_datagram_client_socket( byte[] hostname,
 								  int port,
-								  boolean bcast ) {
-      return new datagram_client_socket( hostname, port, bcast );
+								  boolean bcast,
+                                                                  symbol family ) {
+       return new datagram_client_socket( hostname, port, bcast, family );
    }
 
-   public static datagram_socket bgl_make_datagram_server_socket( int port ) {
-      return new datagram_server_socket( port );
+   public static datagram_socket bgl_make_datagram_server_socket( int port,
+                                                                  symbol family ) {
+       return new datagram_server_socket( port, family );
    }
 
    public static datagram_socket bgl_make_datagram_unbound_socket( symbol family ) {


### PR DESCRIPTION
make-client-socket and make-server-socket now both accept a domain
keyword argument specifying the address family for the resulting
socket. By default, domain is 'inet (i.e., IPv4) but can also be
'inet6 (i.e., IPv6), 'unix, or 'local. This necessitated extending
make-server-socket to support unix sockets. The required file path is
provided in the name keyword argument.

The make-datagram-server-socket, make-datagram-unbound-socket, and
make-datagram-client-socket were similarly extended with an optional
domain argument, default value 'inet. Minor bugs were fixed in
make-datagram-client-socket.

Finally, make-ssl-client-socket and make-ssl-server-socket were
also modified to have a domain keyword argument specifying the address
family. The default value is 'inet. This is passed on to the
corresponding make-client-socket and make-server-socket calls.