### PR TITLE
Quick fixes to configure

### DIFF
--- a/configure
+++ b/configure
@@ -18,7 +18,7 @@
 #*    Bigloo revision number                                           */
 #*---------------------------------------------------------------------*/
 release=4.5b
-buildrelease=4.5a
+buildrelease=4.5a-1
 version=
 bigloourl=http://www-sop.inria.fr/indes/fp/Bigloo
 biglooftp=ftp://ftp-sop.inria.fr/indes/fp/Bigloo
@@ -50,7 +50,7 @@ apis="$importantapis gstreamer phidget alsa pulseaudio wav flac mpg123 phone ava
 bee=partial # "partial" or "full"
 
 #*--- build directory -------------------------------------------------*/
-buildtmp=$TMPDIR
+buildtmp=$tmpdir
 
 #*--- C back-end user configure ---------------------------------------*/
 nativebackend=yes # set to "no" not to install the native (C) back-end
@@ -1722,7 +1722,8 @@ if [ $bootmethod = "source" ]; then
   fi
 
   if [ $? != 0 ]; then
-    echo "command failed \"wget $ftp/bigloo-$buildrelease -o $TMPDIR/bigloo-$buildrelease.tar.gz\""
+    echo "command failed \"wget $biglooftp/bigloo-$buildrelease -o download/bigloo-$buildrelease.tar.gz\""
+    rm -f download/bigloo-$buildrelease.tar.gz
     wget --help > /dev/null 2> /dev/null
     
     if [ $? != 0 ]; then


### PR DESCRIPTION
TMPDIR is not defined - only tmpdir.
Renamed version to pull as 4.5a is not available in FTP. Also, fixed error messages in case ftp wget fails.