### PR TITLE
Suppress noisy printing of stack traces due to io errors in jvm runtime

### DIFF
--- a/runtime/Jlib/foreign.java
+++ b/runtime/Jlib/foreign.java
@@ -6710,8 +6710,10 @@ public final class foreign
       } catch( Exception e ) {
 	 String msg = e.getMessage();
 
-	 final stackwriter sw = new stackwriter( System.out, true );
-	 e.printStackTrace( sw );
+         // Commenting out the following stack trace printing to reduce noisy and confusing
+         // ouput. If debugging problems, uncomment.
+	 // final stackwriter sw = new stackwriter( System.out, true );
+	 // e.printStackTrace( sw );
 	 
 	 bigloo.runtime.Llib.error.bgl_system_failure(
 	    (e instanceof java.net.SocketTimeoutException ?


### PR DESCRIPTION
rgc_fill_buffer in foreign.java previously printed a complete Java stack trace when an exception was thrown. While helpful in some cases, in the common scenario where the exception is caught and handled, this resulted in noisy and confusing output. Commenting out the code removes this noise.