### PR TITLE
Prepare for GCC 14

### DIFF
--- a/api/libbacktrace/src/Clib/bglbacktrace.c
+++ b/api/libbacktrace/src/Clib/bglbacktrace.c
@@ -191,7 +191,6 @@ bgl_backtrace_foreach(void *proc) {
    if (env) {
       struct backtrace_state *bt_state = libbacktrace_get_state(env);
       backtrace_full(bt_state, 0, backtrace_foreach_cb, cbe, proc);
-      return BUNSPEC;
    }
 }
 

--- a/api/ssl/src/C/bglssl.c
+++ b/api/ssl/src/C/bglssl.c
@@ -1743,7 +1743,7 @@ bgl_ssl_connection_clear_pending( ssl_connection ssl ) {
 /*    bgl_get_session_callback ...                                     */
 /*---------------------------------------------------------------------*/
 static SSL_SESSION *
-bgl_get_session_callback( SSL *ssl, unsigned char *key, int len, int *copy ) {
+bgl_get_session_callback( SSL *ssl, const unsigned char *key, int len, int *copy ) {
    ssl_connection c = (ssl_connection)(SSL_get_app_data( ssl ));
    SSL_SESSION *sess = CCON( c )->BgL_z42nextzd2sessionz90;
    
@@ -2308,7 +2308,7 @@ bgl_ssl_connection_get_peer_certificate( ssl_connection ssl ) {
       }
 
       STACK_OF(ASN1_OBJECT) *eku =
-	 (ASN1_OBJECT *)X509_get_ext_d2i( peer_cert, NID_ext_key_usage, NULL, NULL );
+	 (STACK_OF(ASN1_OBJECT) *)X509_get_ext_d2i( peer_cert, NID_ext_key_usage, NULL, NULL );
       if( eku != NULL ) {
 	 char buf[ 256 ];
 	 int len = sk_ASN1_OBJECT_num( eku );

--- a/autoconf/openssl-getter
+++ b/autoconf/openssl-getter
@@ -73,7 +73,7 @@ int main( int argc, char *argv[] ) {
     DH *dh;
     const BIGNUM *key;
     DH_get0_key( dh, &key, 0 );
-    return SSL_CTX_get_ssl_method( ctx );
+    return (SSL_CTX_get_ssl_method( ctx ) == NULL) ? 1 : 0;
 }
 EOF
 


### PR DESCRIPTION
GCC 14 is going to be pickier about things like implicit return values, mismatched pointer types, and implicit conversions between pointers and ints.  The Fedora project is trying to prepare for GCC 14:
- https://fedoraproject.org/wiki/Changes/PortingToModernC
- https://fedoraproject.org/wiki/Toolchain/PortingToModernC

This commit fixes several code issues that will be errors when GCC 14 is released:
- `bgl_backtrace_foreach` has a return type of void, but contains a return statement with a value
- `bgl_get_session_callback` has the wrong type, due to a missing const keyword on one parameter
- `bgl_ssl_connection_get_peer_certificate` contains an assigment of one pointer type to a variable of a different pointer type
- `autoconf/openssl-getter` fails because the test code returns a pointer type from main, which is declared to return int
