### PR TITLE
Add missing INPUT_MMAP_PORTP method to JVM runtime

### DIFF
--- a/runtime/Ieee/port.scm
+++ b/runtime/Ieee/port.scm
@@ -269,6 +269,8 @@
 		  "bgl_open_input_substring_bang")
 	       (method static $open-input-mmap::obj (::mmap ::bstring ::long ::long)
 		  "bgl_open_input_mmap")
+               (method static $input-mmap-port?::bool (::obj)
+		   "INPUT_MMAP_PORTP")
 	       (method static $open-input-procedure::obj (::procedure ::bstring)
 		  "bgl_open_input_procedure")
 	       (method static $input-port-timeout-set!::bool (::input-port ::long)

--- a/runtime/Jlib/foreign.java
+++ b/runtime/Jlib/foreign.java
@@ -6339,7 +6339,12 @@ public final class foreign
       {
 	 return BFALSE;
       }
-   
+    
+   public static boolean INPUT_MMAP_PORTP(Object o)
+      {
+	 return false;
+      }
+
    public static Object bgl_open_input_procedure(procedure p, byte[] b)
       {
 	 return new input_procedure_port( p, b );


### PR DESCRIPTION
port.scm was referencing the method INPUT_MMAP_PORTP not implemented in the JVM runtime causing a build error. Providing a stub implementation enables a successful build of the JVM backend.