### PR TITLE
fix bug in srfi1's filter-map that caused erroneous results

### DIFF
--- a/api/srfi1/src/Llib/srfi1.srfi
+++ b/api/srfi1/src/Llib/srfi1.srfi
@@ -1008,7 +1008,7 @@
 (define (filter-map f l0 . l)
    (cond
       ((null? l)
-       (filter-map-2 f l))
+       (filter-map-2 f l0))
       (else
        (let loop ((l (cons l0 l)))
 	  (if (null? (car l))


### PR DESCRIPTION
When filter-map was called with a single list, it failed to filter and map across that list since filter-map-2 was applied to the empty list of lists instead of the first list. I stumbled upon this when adapting srfi196 ranges which relies on filter-map from srfi1