### PR TITLE
jvm pthread fixes

### DIFF
--- a/api/pthread/src/Java/bglpdynamic.java
+++ b/api/pthread/src/Java/bglpdynamic.java
@@ -18,11 +18,19 @@ import bigloo.*;
 /*---------------------------------------------------------------------*/
 /*    bglpdynamic                                                      */
 /*---------------------------------------------------------------------*/
-public class bglpdynamic extends bigloo.bgldynamic {
+public class bglpdynamic extends bigloo.bgldynamic { 
    protected static void setup() {
       bigloo.bgldynamic.abgldynamic = new bglpdynamic();
    }
 
+   public bglpdynamic() {
+       super();
+   }
+    
+   public bglpdynamic (final bgldynamic o) {
+       super(o);
+   }
+    
    public bgldynamic get() {
       Thread t = java.lang.Thread.currentThread();
 

--- a/api/pthread/src/Java/bglpmutex.java
+++ b/api/pthread/src/Java/bglpmutex.java
@@ -32,7 +32,7 @@ public class bglpmutex extends bigloo.mutex {
    }
 
    protected Object thread = null;
-   protected String state = "not-abandoned";
+   protected String state = "unlocked";
    
    private Object specific;
 
@@ -57,7 +57,7 @@ public class bglpmutex extends bigloo.mutex {
 	 
          if( m.thread == thread ) {
             m.release_lock();
-            m.state = "abandoned";
+            m.state = "locked";
          }
          w = foreign.CDR( (pair)w );
       }
@@ -69,7 +69,7 @@ public class bglpmutex extends bigloo.mutex {
            if( mutex.tryLock(ms, TimeUnit.MILLISECONDS) ) {
                /* mark mutex owned */
                thread = bglpthread.current_thread();
-               System.out.printf("thread %s is locking%n", thread); 
+               //System.out.printf("thread %s is locking%n", thread); 
                state = null;
                res = 0;
            }

--- a/api/pthread/src/Java/bglpthread.java
+++ b/api/pthread/src/Java/bglpthread.java
@@ -80,8 +80,7 @@ public class bglpthread extends Thread {
    // The thread entry-point
    public void start( Object t, boolean _b ) {
       thread = t;
-      env = new bgldynamic( bgldynamic.abgldynamic.get() );
-      
+      env = new bglpdynamic( bgldynamic.abgldynamic.get() );
       start();
    }
 

--- a/runtime/Jlib/bgldynamic.java
+++ b/runtime/Jlib/bgldynamic.java
@@ -34,7 +34,7 @@ public class bgldynamic
    public output_port current_output_port;
    public output_port current_error_port;
    
-   public Object current_display;
+   public Object current_display = unspecified.unspecified;
    
    public int mvalues_number;
    public final Object[] mvalues_values= { unspecified.unspecified,
@@ -58,9 +58,9 @@ public class bgldynamic
    public Object exitd_val;
    public Object error_handler;
    public Object uncaught_exception_handler;
-   public Object error_notifiers;
-   public Object interrupt_notifier;
-   public Object current_thread;
+   public Object error_notifiers = bigloo.foreign.BNIL;
+   public Object interrupt_notifier = bigloo.foreign.BNIL;
+   public Object current_thread = 0;
    public Object debug_alist = bigloo.foreign.BNIL;
    public Object lexical_stack = bigloo.foreign.BNIL;
    public Object bytecode = bigloo.foreign.BUNSPEC;
@@ -95,13 +95,22 @@ public class bgldynamic
 				     unspecified.unspecified),
 			    unspecified.unspecified );
       
-      error_handler = nil.nil;
-
+      //error_handler = nil.nil;
+      error_handler = new pair( unspecified.unspecified, bigloo.foreign.BFALSE );
+      uncaught_exception_handler = bigloo.nil.nil;
+      
       mvalues_number = 1;
 
       current_input_port = o.current_input_port;
       current_output_port = o.current_output_port;
       current_error_port = o.current_error_port;
+
+      current_display = o.current_display;
+
+      interrupt_notifier = o.interrupt_notifier;
+
+      thread_backend = o.thread_backend;
+     
       
       thread_backend = o.thread_backend;
       current_thread = o.current_thread;


### PR DESCRIPTION
This fixes errors seen in the recette for the jvm implementation of the pthread library. The first is an error in the handling of the dynamic environment in  multi-threaded programs and the others were minor differences in the handling of mutex-state between the jvm and posix implementations.