### PR TITLE
fix unexpected java exception for IndexOutOfBoundsExceptions

### DIFF
--- a/runtime/Llib/error.scm
+++ b/runtime/Llib/error.scm
@@ -367,7 +367,8 @@
       ((=fx sysno $errno-typename-error)
        (raise (typename-error #f #f proc msg obj)))
       ((=fx sysno $errno-index-out-of-bound-error)
-       (raise (index-out-of-bounds-error #f #f proc obj msg -1)))
+       (raise (instantiate::&index-out-of-bounds-error (fname #f) (location #f) (proc proc)
+                 (msg msg) (obj obj) (index -1))))
       (else
        (error proc msg obj))))
 


### PR DESCRIPTION
When indexing outside the bounds of a vector, an unexpected java exception error is displayed. A simple example is:

          (vector-ref '#(0 1) 4)

As is seen in the c-backend , this should instead throw an &index-out-of-bounds-error which can be caught and handled. Modifying error/errorno to directly instantiate and raise the exception corrects the problem. It is unclear why the former implementation invoking the procedure index-out-of-bounds-error fails. In tracing the execution, the index-out-of-bounds-error procedure does not even seem to be executed; print statements added to the procedure are never seen.