### PR TITLE
Correct jvm pthread state implementation

### DIFF
--- a/api/pthread/recette/recette.scm
+++ b/api/pthread/recette/recette.scm
@@ -415,7 +415,12 @@
 			      (mutex-toggle m #t mutex-toggle)))))))
 	 (thread-join! th1)
 	 (mutex-state m)))
-   :result 'locked)
+   ;; The c and jvm backends provide different results due to the jvm
+   ;; backend closing all mutexes owned by the thread upon exit. See
+   ;; bglpthread::run in Java/bglpthread.java
+   :result (cond-expand
+              (bigloo-c 'locked)
+              (bigloo-jvm 'unlocked)))
 
 ;*---------------------------------------------------------------------*/
 ;*    mutex-timed-lock ...                                             */

--- a/api/pthread/src/Java/bglpmutex.java
+++ b/api/pthread/src/Java/bglpmutex.java
@@ -57,7 +57,7 @@ public class bglpmutex extends bigloo.mutex {
 	 
          if( m.thread == thread ) {
             m.release_lock();
-            m.state = "locked";
+            m.state = "unlocked";
          }
          w = foreign.CDR( (pair)w );
       }
@@ -70,7 +70,7 @@ public class bglpmutex extends bigloo.mutex {
                /* mark mutex owned */
                thread = bglpthread.current_thread();
                //System.out.printf("thread %s is locking%n", thread); 
-               state = null;
+               state = "locked";
                res = 0;
            }
            
@@ -88,7 +88,7 @@ public class bglpmutex extends bigloo.mutex {
            mutex.lock();
            /* mark mutex owned */
            thread = bglpthread.current_thread();
-           state = null;
+           state = "locked";
            res = 0;
        } catch( Exception e ) {
            foreign.fail( "mutex-lock!", 
@@ -107,7 +107,7 @@ public class bglpmutex extends bigloo.mutex {
        mutex.unlock();
        /* mark mutex no longer owned */
        thread = null;
-       state = "not-abandoned";
+       state = "unlocked";
        return 0;
    }
 


### PR DESCRIPTION
The prior change, while permitting the recette to pass, was incorrect. This was pointed out by Andreas Franke in a private communication. The current changes correct that error and also take into account differences in pthread behavior betwee the jvm and c backends, namely all mutexes owned by a thread are closed by thread exit in the jvm backend. See bglpthread::run in Java/bglpthread.java.