### PR TITLE
Make bgl_setrlimit return type match declaration

### DIFF
--- a/runtime/Clib/csystem.c
+++ b/runtime/Clib/csystem.c
@@ -834,20 +834,16 @@ bgl_getrlimit(long resource) {
 }
 
 /*---------------------------------------------------------------------*/
-/*    obj_t                                                            */
+/*    bool_t                                                           */
 /*    bgl_setrlimit ...                                                */
 /*---------------------------------------------------------------------*/
-obj_t
+bool_t
 bgl_setrlimit(long resource, long soft, long hard) {
 #if BGL_HAVE_GETRLIMIT
    struct rlimit lim = { .rlim_cur = soft, .rlim_max = hard };
-   if (!setrlimit(resource, &lim)) {
-      return BTRUE;
-   } else {
-      return BFALSE;
-   }
+   return !setrlimit(resource, &lim);
 #else
-   return BFALSE;
+   return 0;
 #endif
 }
 


### PR DESCRIPTION
The setrlimit declaration in runtime/Llib/os.scm claims the return type is bool, but the C code doesn't match.  The Fedora project builds with link-time optimization (LTO), and the link time optimizer issued a warning about the type mismatch.