### PR TITLE
Add support for open-input-mmap and input-mmap-ports to the jvm backend

### DIFF
--- a/recette/Makefile
+++ b/recette/Makefile
@@ -58,7 +58,7 @@ ICOMMON		= vital bps bool list vector srfi4 struct print \
                   rgc_eval rgc hash module import1 import2 \
                   cfa2 cell hygiene wind dsssl sua peek callcc fringe \
                   unicode optim pregexp lalr system date process \
-                  mmap weakptr crypto crc
+                  mmap input_mmap_port weakptr crypto crc
 
 OCOMMON		= object object_sans \
                   object1 object1_sans \

--- a/recette/input_mmap_port.scm
+++ b/recette/input_mmap_port.scm
@@ -1,0 +1,41 @@
+;*=====================================================================*/
+;*    /bigloo/recette/input_mmap_port.scm                              */
+;*    -------------------------------------------------------------    */
+;*    Author      :  Joseph Donaldson                                  */
+;*    Creation    :  Tue Jan 16 07:26:45 2024                          */
+;*    Last change :  Tue Jan 16 09:00:00 2023 (Joseph Donaldson)       */
+;*    Copyright   :  2024 Joseph Donaldson                             */
+;*    -------------------------------------------------------------    */
+;*    MMAP testing                                                     */
+;*=====================================================================*/
+
+;*---------------------------------------------------------------------*/
+;*    The module                                                       */
+;*---------------------------------------------------------------------*/
+(module input-mmap-port
+   (import  (main "main.scm"))
+   (include "test.sch")
+   (export  (test-input-mmap-port)))
+
+;*---------------------------------------------------------------------*/
+;*    test-mmap ...                                                    */
+;*---------------------------------------------------------------------*/
+(define (test-input-mmap-port)
+   (test-module "test-input-mmap-port" "input-mmap-port.scm")
+   (let* ((path "misc/input.txt")
+          (mm (open-mmap path :read #t))
+          (mmap-input (open-input-mmap mm))
+          (c (with-input-from-file path (lambda () (read-char))))
+          (s (with-input-from-file path (lambda () (read-chars 20)
+                                           (read-chars 9)))))
+      (test "input-mmap-port?.1" (input-mmap-port? mmap-input) #t)
+      (test "input-mmap-port?.2" (input-mmap-port? list) #f)
+      (test "input-mmap-port?.3" (input-mmap-port? 1) #f)
+      (test "input-mmap-port?.4" (input-mmap-port? "foo") #f)
+      (test "input-mmap-port read-char" (read-char mmap-input) c)
+      (input-port-reopen! mmap-input)
+      (test "input-mmap-port input-port-reopen! then read-char" (read-char mmap-input) c)
+      (set-input-port-position! mmap-input 20)
+      (test "input-mmap-port set-input-port-position!" (read-chars 9 mmap-input) s)
+      (test "input-mmap-port close-input-port" (close-input-port mmap-input) mmap-input)
+      (close-mmap mm)))

--- a/recette/main.scm
+++ b/recette/main.scm
@@ -43,6 +43,7 @@
 	   rgc
 	   lalr
 	   input-port
+           input-mmap-port
 	   mmap
 	   read
 	   callcc
@@ -301,6 +302,7 @@
 	  (if-module 'rgc-insert test-rgc-insert)
 	  (if-module 'lalr test-lalr)
 	  (if-module 'input-port test-input-port)
+          (if-module 'input-mmap-port test-input-mmap-port)
 	  (if-module 'mmap test-mmap)
 	  (if-module 'read test-read)
 	  (if *callcc?*

--- a/runtime/Ieee/port.scm
+++ b/runtime/Ieee/port.scm
@@ -1145,11 +1145,11 @@
       ((>fx end (elong->fixnum (mmap-length mmap)))
        (error "open-input-mmap" "End offset out of bounds" end))
       (else
-       (let ((buffer (get-port-buffer "open-input-file" #f
+       (let ((buffer (get-port-buffer "open-input-mmap" #f
 			(if (<fx (-fx end start) c-default-io-bufsiz)
 			    (-fx end start)
 			    c-default-io-bufsiz))))
-	  ($open-input-mmap mmap buffer start end)))))
+          ($open-input-mmap mmap buffer start end)))))
 
 ;*---------------------------------------------------------------------*/
 ;*    open-input-procedure ...                                         */

--- a/runtime/Ieee/port.scm
+++ b/runtime/Ieee/port.scm
@@ -267,7 +267,7 @@
 		  "bgl_open_input_substring")
 	       (method static $open-input-substring!::input-port (::bstring ::int ::int)
 		  "bgl_open_input_substring_bang")
-	       (method static $open-input-mmap::obj (::mmap ::bstring ::long ::long)
+	       (method static $open-input-mmap::input-port (::mmap ::bstring ::long ::long)
 		  "bgl_open_input_mmap")
                (method static $input-mmap-port?::bool (::obj)
 		   "INPUT_MMAP_PORTP")

--- a/runtime/Include/bigloo.h
+++ b/runtime/Include/bigloo.h
@@ -679,6 +679,8 @@ union scmobj {
       struct input_port iport;
       /* offset */
       long offset;
+      /* start */
+      long start;
       /* end */
       long end;
    } input_mmap_port;
@@ -1753,7 +1755,7 @@ BGL_RUNTIME_DECL obj_t bgl_init_fx_procedure(obj_t, function_t, int, int);
 
 #define INPUT_GZIP_PORT(o) CREF(o)->input_gzip_port
 #define INPUT_PROCEDURE_PORT(o) CREF(o)->input_procedure_port
-
+#define INPUT_MMAP_PORT(o) CREF(o)->input_mmap_port 
 #define INPUT_PORT(o) CREF(o)->input_port
 
 #define INPUT_PORTP(o) (POINTERP(o) && (TYPE(o) == INPUT_PORT_TYPE))

--- a/runtime/Jlib/foreign.java
+++ b/runtime/Jlib/foreign.java
@@ -6335,14 +6335,14 @@ public final class foreign
 	 return new input_string_port( s, start, end, true );
       }
 
-   public static Object bgl_open_input_mmap(mmap mm, byte[] b, int start, int end)
+   public static input_port bgl_open_input_mmap(mmap mm, byte[] b, int start, int end)
       {
-	 return BFALSE;
+         return new input_mmap_port(mm, b, start, end); 
       }
     
    public static boolean INPUT_MMAP_PORTP(Object o)
       {
-	 return false;
+          return (o instanceof input_mmap_port);
       }
 
    public static Object bgl_open_input_procedure(procedure p, byte[] b)
@@ -6723,7 +6723,7 @@ public final class foreign
          // Commenting out the following stack trace printing to reduce noisy and confusing
          // ouput. If debugging problems, uncomment.
 	 // final stackwriter sw = new stackwriter( System.out, true );
-	 // e.printStackTrace( sw );
+         // e.printStackTrace( sw );
 	 
 	 bigloo.runtime.Llib.error.bgl_system_failure(
 	    (e instanceof java.net.SocketTimeoutException ?

--- a/runtime/Jlib/input_mmap_port.java
+++ b/runtime/Jlib/input_mmap_port.java
@@ -1,0 +1,143 @@
+package bigloo;
+
+import java.io.*;
+
+public class input_mmap_port extends input_port {
+
+    private int start;
+    private int offset;
+    private int end;
+    private bigloo.mmap mm;
+    
+    public input_mmap_port( mmap mm, byte[] buffer, int offset, int end ) {
+      super(new String(mm.name), buffer);
+       
+      this.mm = mm;
+      this.start = offset;
+      this.offset = offset;
+      this.end = end;
+      this.length = end - offset;
+   }
+
+   public boolean rgc_charready() {
+       if (eof || other_eof) {
+           return false;
+       }
+
+       return ((forward+1 < bufpos) || (offset < length));
+   }
+
+   Object bgl_input_port_seek( final int  pos ) throws IOException {
+       obj res = bigloo.foreign.BFALSE;
+       if (pos >= 0 && pos < length) {
+           filepos = start+pos;
+           offset = start+pos;
+           eof = false;
+           matchstart = 0;
+           matchstop = 0;
+           forward = 0;
+           bufpos = 0;
+           lastchar = (byte)'\n';
+           res = bigloo.foreign.BTRUE;
+       } else if (pos == length) {
+           eof = true;
+           res = bigloo.foreign.BTRUE;
+       } else {
+           throw new IOException("illegal seek offset");
+       }
+
+       return res;
+   }
+
+   Object bgl_input_port_reopen()
+       throws IOException
+    {
+      offset = start;
+      bufpos = 0;
+      eof = false;
+      filepos = 0;
+      matchstart = 0;
+      matchstop = 0;
+      forward = 0;
+      lastchar = (byte)'\n';
+      return bigloo.foreign.BTRUE;
+   }
+
+   public void close() {
+      eof = true;
+      other_eof= true;
+      super.close();
+   }
+
+   public boolean rgc_fill_buffer()
+       throws IOException
+    {
+        final int bufsize = this.buffer.length;
+        int bufpose = this.bufpos;
+        final int matchstart = this.matchstart;
+        final byte[] buffer = this.buffer;
+        
+        if (matchstart > 0)
+            {
+                // we shift the buffer left and we fill the buffer */
+                final int movesize = bufpose-matchstart;
+                
+                for ( int i= 0 ; i < movesize ; ++i )
+                    buffer[i] = buffer[matchstart+i];
+                
+                bufpose -= matchstart;
+                this.matchstart = 0;
+                this.matchstop -= matchstart;
+                this.forward -= matchstart;
+                this.lastchar = buffer[matchstart-1];
+                
+                return rgc_size_fill_mmap_buffer( bufpose, bufsize-bufpose );
+            }
+        
+        if (bufpose < bufsize)
+            {
+                return rgc_size_fill_mmap_buffer( bufpose, bufsize-bufpose );
+            }
+        
+        // we current token is too large for the buffer */
+        // we have to enlarge it.                       */
+        rgc_double_buffer();
+        
+        return rgc_fill_buffer();
+    } 
+    
+    final boolean rgc_size_fill_mmap_buffer( int bufpose, final int  size )
+        throws IOException
+    {
+        final int nbcopy = ((offset + size) < length) ? size : (int)(length - offset);
+        boolean res = true;
+        if (nbcopy == 0) {
+            eof = true;
+            res = false;
+        } else {
+            for(int i = 0; i < nbcopy; i++) {
+                buffer[bufpose+i] = mm.map.get(offset+i);
+            }
+            offset += nbcopy;
+            bufpose += nbcopy;
+        }
+        this.bufpos = bufpose;
+        
+        return res;        
+    }
+
+    public Object bgl_input_port_clone( input_port src )
+    {
+     super.bgl_input_port_clone( src );
+     mm = ((input_mmap_port)src).mm;
+     offset = ((input_mmap_port)src).offset;
+     end = ((input_mmap_port)src).end;
+     length = src.length;
+     return this;
+    }
+
+    public void write( final output_port  p )
+    {
+        p.write( "#<input_mmap_port:" + name + ">" );
+    }
+}

--- a/runtime/Jlib/input_mmap_port.java
+++ b/runtime/Jlib/input_mmap_port.java
@@ -116,7 +116,7 @@ public class input_mmap_port extends input_port {
             res = false;
         } else {
             for(int i = 0; i < nbcopy; i++) {
-                buffer[bufpose+i] = mm.map.get(offset+i);
+                buffer[bufpose+i] = (byte)foreign.BGL_MMAP_REF(mm, offset+i);
             }
             offset += nbcopy;
             bufpose += nbcopy;

--- a/runtime/Jlib/input_port.java
+++ b/runtime/Jlib/input_port.java
@@ -48,19 +48,13 @@ public abstract class input_port extends obj
 
     if( nsize < bufsize ) return;
     
-    if (bufsize == 2)
-      foreign.fail( "input-port",
-                    "Can't enlarge buffer for non bufferized port (see the user manual for details)",
-                    this );
-    else
-    {
-      final byte[] obuffer= buffer;
-      final byte[] nbuffer= new byte[nsize];
-
-      for ( int i= 0 ; i < bufsize ; ++i )
+    final byte[] obuffer= buffer;
+    final byte[] nbuffer= new byte[nsize];
+    
+    for ( int i= 0 ; i < bufsize ; ++i )
         nbuffer[i]= obuffer[i];
-      buffer= nbuffer;
-    }
+    buffer= nbuffer;
+  
   }
 
    public final void rgc_double_buffer() {

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -183,7 +183,7 @@ endif
 JLIB		= foreign buffer configure stackwriter\
                   bbool output_string_port output_procedure_port \
 		  bchar input_console_port pair \
-		  bexception input_file_port \
+		  bexception input_file_port  input_mmap_port\
                   procedure \
 		  bignum bint input_port real \
 		  bllong belong input_string_port input_pipe_port rest \


### PR DESCRIPTION
Also fixed the c-backend's implementation of bgl_input_mmap_seek and enabled the reopening of input-mmap-ports.