### PR TITLE
Correct string type declaration in SSL library

### DIFF
--- a/api/ssl/src/C/bglssl.c
+++ b/api/ssl/src/C/bglssl.c
@@ -3399,7 +3399,7 @@ bgl_pkcs5_pbkdf2_hmac_sha1(obj_t pass, obj_t salt, int iter, int keylen) {
 /*---------------------------------------------------------------------*/
 obj_t bgl_ssl_error_string() {
    int err = ERR_get_error();
-   char *string[128];
+   char string[128];
    
    ERR_error_string_n(err, string, 128);
 


### PR DESCRIPTION
Previously, we were creating an array of char* pointers instead of chars. Reasonably, this causes a compiler error with recent versions of gcc (>= 14).