### PR TITLE
Introduce a checkcast instruction to placate java verifier

### DIFF
--- a/comptime/SawJvm/compile.scm
+++ b/comptime/SawJvm/compile.scm
@@ -79,6 +79,7 @@
       (code! me 'from) )
    (code! me '(aload argv))
    (code! me '(invokestatic listargv))
+   (code! me '(checkcast pair))
    (call-global me (find-global 'bigloo_main *module*))
    (code! me '(pop))
    (code! me '(return))

--- a/runtime/Jlib/foreign.java
+++ b/runtime/Jlib/foreign.java
@@ -4421,7 +4421,7 @@ public final class foreign
    ////
    // CLASS
    ////
-   public static bclass BGL_AS_CLASS(Object o) {
+   public static Object BGL_AS_CLASS(Object o) {
       return (bclass)o;
    }
    


### PR DESCRIPTION
recent updates to the jvm verifier have made it stricter than before, requiring the addition of (checkcast pair) in main before calling bigloo_main.

