### PR TITLE
enhance cigloo to better handle parsing modern c and gcc extensions

### DIFF
--- a/cigloo/Engine/engine.scm
+++ b/cigloo/Engine/engine.scm
@@ -31,6 +31,7 @@
 ;*    cigloo ...                                                       */
 ;*---------------------------------------------------------------------*/
 (define (cigloo)
+
    ;; the reader settup
    (init-lexer!)
    (if (string? *dest*)
@@ -53,6 +54,7 @@
 ;*    engine ...                                                       */
 ;*---------------------------------------------------------------------*/
 (define (engine)
+   ;(bigloo-debug-set! 300)
    ;; first of all, we emit identification comment and
    ;; the include Bigloo clauses.
    (if (>=fx *verbose* 0)

--- a/cigloo/Engine/param.scm
+++ b/cigloo/Engine/param.scm
@@ -137,8 +137,11 @@
      (file*       . "file")
      (short       . "short")
      (int         . "int")
+     (uint        . "uint")
      (long        . "long")
-     (longlong    . "llong") 
+     (ulong       . "ulong")
+     (longlong    . "llong")
+     (ulonglong    . "ullong")
      (signed      . "sint")
      (unsigned    . "uint")
      (float       . "float")
@@ -148,14 +151,16 @@
    '((char     . "uchar")
      (short    . "ushort")
      (int      . "uint")
-     (long     . "ulong")))
+     (long     . "ulong")
+     (longlong . "ullong")))
 
    
 (define *c-signed-type-alist*
-   '((char     . "schar")
+   '((char     . "char")
      (short    . "short")
      (int      . "int")
-     (long     . "long")))
+     (long     . "long")
+     (longlong . "llong")))
 
 (define *default-type* "int")
 

--- a/cigloo/Engine/translate.scm
+++ b/cigloo/Engine/translate.scm
@@ -93,10 +93,12 @@
 ;*    translate-ast ...                                                */
 ;*---------------------------------------------------------------------*/
 (define (translate-ast ast)
+  
    (if (not (ast? ast))
        'ignore
        (ast-case ast
 	  ((fun-def)
+       
 	   (translate-function-definition ast))
 	  ((declare)
 	   (translate-declaration ast))

--- a/cigloo/Makefile
+++ b/cigloo/Makefile
@@ -27,7 +27,7 @@ CIGLOO_DEST	= $(BOOTBINDIR)/cigloo$(EXE_SUFFIX)
 #*---------------------------------------------------------------------*/
 #*    Compilation flags                                                */
 #*---------------------------------------------------------------------*/
-BFLAGS		= -lib-dir $(BOOTLIBDIR) -afile .afile -O2 -fsharing -unsafe $(SHRD_BDE_OPT)
+BFLAGS		= -export-exports -lib-dir $(BOOTLIBDIR) -afile .afile -g3 -O2 -fsharing -unsafe $(SHRD_BDE_OPT)
 EFLAGS		=
 
 #*---------------------------------------------------------------------*/

--- a/cigloo/Parser/cpp.scm
+++ b/cigloo/Parser/cpp.scm
@@ -92,7 +92,10 @@
 	  (? (or long-suffix
 		 (: long-suffix unsigned-suffix)
 		 unsigned-suffix
-		 (: unsigned-suffix long-suffix))))
+		 (: unsigned-suffix long-suffix)
+                 (: long-suffix long-suffix unsigned-suffix)
+                 (: long-suffix long-suffix)
+                 (: unsigned-suffix long-suffix long-suffix))))
        (list 'INTEGER-CONSTANT (the-string)))
 
       ;; floating-point constant
@@ -173,7 +176,7 @@
 	'done)
        ((DEFINE-VAR ID value)
 	(if *define*
-	    (let ((cell  (assq value *c-type-alist*))
+            (let ((cell  (assq value *c-type-alist*))
 		  (coord DEFINE-VAR)
 		  (m-id  (car ID)))
 	       (cond
@@ -273,7 +276,13 @@
        ((CHAR-CONSTANT)
 	'char)
        ((INTEGER-CONSTANT)
-	'long)
+        (cond
+           ((pregexp-match ".*(u|U)|(l|L)(l|L)$" (car INTEGER-CONSTANT))
+            'ulonglong)
+           ((pregexp-match ".*(l|L)(l|L)$" (car INTEGER-CONSTANT))
+            'longlong)
+           (else
+            'long)))
        ((FLOAT-CONSTANT)
 	'double)
        ((???)

--- a/cigloo/Parser/lexer.scm
+++ b/cigloo/Parser/lexer.scm
@@ -55,6 +55,7 @@
      "__restrict"
      "__restrict__"
      "return"
+     "_Static_assert" ; C11 Keyword
      "short"
      "signed"
      "sizeof"
@@ -68,10 +69,12 @@
      "volatile"
      "while"
      "FILE"
-     "obj_t"))
+     "obj_t"
+     "_Bool"
+     "_Float128"))
 
 (define *gcc-keyword-list*
-   '("__attribute__" "inline" "__inline__" "__inline" "__extension__" "__gnuc_va_list"))
+   '("__asm__" "__attribute__" "inline" "__inline__" "__inline" "__extension__" "__gnuc_va_list" "__builtin_va_list"))
 
 ;*---------------------------------------------------------------------*/
 ;*    lexer initialization                                             */
@@ -165,7 +168,10 @@
 	  (? (or long-suffix
 		 (: long-suffix unsigned-suffix)
 		 unsigned-suffix
-		 (: unsigned-suffix long-suffix))))
+		 (: unsigned-suffix long-suffix)
+                 (: long-suffix long-suffix)
+                 (: unsigned-suffix long-suffix long-suffix)
+                 (: long-suffix long-suffix unsigned-suffix))))
        (list 'CONSTANT (the-coord (the-port)) (the-string)))
 
       ;; floating-point constant
@@ -178,11 +184,12 @@
        (list 'CONSTANT (the-coord (the-port)) (the-string)))
 
       ;; character constant
-      ((: (? #\L) #\' (+ all) #\')
+      ((: (? #\L) #\' (or (out #\\ #\') (: #\\ all)
+                         (: #\\ (in #\x #\X) (>= 2 xdigit)))  #\')
        (list 'CONSTANT (the-coord (the-port)) (the-string)))
 
       ;; string constant
-      ((: (? #\L) #\" (* (out #\")) #\")
+      ((: (? #\L) #\" (* (or (out #a000 #\\ #\") (: #\\ all))) #\")
        (list 'CONSTANT (the-coord (the-port)) (the-string)))
 
       ;; operators

--- a/cigloo/Parser/lexer.scm
+++ b/cigloo/Parser/lexer.scm
@@ -74,7 +74,7 @@
      "_Float128"))
 
 (define *gcc-keyword-list*
-   '("__asm__" "__attribute__" "inline" "__inline__" "__inline" "__extension__" "__gnuc_va_list" "__builtin_va_list"))
+   '("__asm__" "__attribute__" "__attribute" "inline" "__inline__" "__inline" "__extension__" "__gnuc_va_list" "__builtin_va_list"))
 
 ;*---------------------------------------------------------------------*/
 ;*    lexer initialization                                             */
@@ -185,7 +185,8 @@
 
       ;; character constant
       ((: (? #\L) #\' (or (out #\\ #\') (: #\\ all)
-                         (: #\\ (in #\x #\X) (>= 2 xdigit)))  #\')
+                         (: #\\ (in #\x #\X) (** 1 4 xdigit))
+                         (: #\\ (** 1 3 odigit)))  #\')
        (list 'CONSTANT (the-coord (the-port)) (the-string)))
 
       ;; string constant

--- a/cigloo/Parser/parser.scm
+++ b/cigloo/Parser/parser.scm
@@ -696,7 +696,9 @@
        ((static-assert-statement)
         #unspecified)
        ((gcc-attribute-statement)
-        #unspecified))
+        #unspecified)
+       ((gcc-asm-statment)
+        '()))
       
       
       (labeled-statement
@@ -789,12 +791,15 @@
        ((return SEMI-COMMA)
 	#unspecified)
        ((return expr SEMI-COMMA)
-	#unspecified)
-       )
+	#unspecified))
 
       ;; handle C11 _Static_assert keyword
       (static-assert-statement
          ((_Static_assert PAR-OPEN expr PAR-CLO SEMI-COMMA)
+          #unspecified))
+
+      (gcc-asm-statment
+         ((gcc-asm SEMI-COMMA)
           #unspecified))
 
       ;; handle attributes modifying expressions and statements 

--- a/cigloo/Parser/parser.scm
+++ b/cigloo/Parser/parser.scm
@@ -38,7 +38,7 @@
        < > __asm__ asm auto break case char const __const continue default do double
        else enum extern float for fortran goto if int long register FILE
        return short signed sizeof static _Static_assert struct switch typedef union unsigned
-       void volatile while __attribute__ inline __inline__ __inline
+       void volatile while __attribute__ __attribute inline __inline__ __inline
        __extension__ obj_t
        restrict __restrict__ __restrict
        __gnuc_va_list __builtin_va_list _Bool _Float128 )
@@ -832,8 +832,14 @@
         ((gcc-attribute gcc-attributes)
           #unspecified))
 
-      (gcc-attribute
-         ((__attribute__ PAR-OPEN PAR-OPEN gcc-attribute-list PAR-CLO PAR-CLO)
+      (attribute-spec
+         ((__attribute__)
+          #unspecified)
+         ((__attribute)
+          #unspecified))
+      
+      (gcc-attribute-values
+         ((attribute-spec PAR-OPEN PAR-OPEN gcc-attribute-list PAR-CLO PAR-CLO)
           #unspecified))
 
       (gcc-attribute-list

--- a/cigloo/Parser/parser.scm
+++ b/cigloo/Parser/parser.scm
@@ -838,7 +838,7 @@
          ((__attribute)
           #unspecified))
       
-      (gcc-attribute-values
+      (gcc-attribute
          ((attribute-spec PAR-OPEN PAR-OPEN gcc-attribute-list PAR-CLO PAR-CLO)
           #unspecified))
 

--- a/cigloo/Translate/decl.scm
+++ b/cigloo/Translate/decl.scm
@@ -107,7 +107,7 @@
 ;*---------------------------------------------------------------------*/
 (define (correct-storage-class-spec? storage-spec)
    (or (null? storage-spec)
-       (and (pair? storage-spec) (null? (cdr storage-spec)))))
+      (and (pair? storage-spec) (null? (cdr storage-spec)))))
 
 ;*---------------------------------------------------------------------*/
 ;*    type-spec-of-decl-spec ...                                       */

--- a/runtime/Lalr/driver.scm
+++ b/runtime/Lalr/driver.scm
@@ -78,7 +78,7 @@
 	    (act     #f)
 	    (eof?    #f)
 	    (debug   (>=fx (bigloo-debug) (lalr-debug))))
-	 
+         
 	 (let loop ((sp 0))
 	    (set! state (vector-ref stack sp))
 	    (set! acts (vector-ref action-table state))
@@ -110,6 +110,8 @@
 	    (when debug
 	       (display "LALR TRACE: input=" (current-error-port))
 	       (write in (current-error-port))
+               (display " attr= " (current-error-port))
+               (write attr (current-error-port))
 	       (display " state=" (current-error-port))
 	       (write state (current-error-port))
 	       (display " sp=" (current-error-port))


### PR DESCRIPTION
This includes better support for gcc attributes, asm exprs/statements,
and _Static_assert. Corrections to string and character literal
parsing were also made.

With these changes, we can now successfully parse many current c library headers. Notcurses and GTK were used as test cases. 

gcc -E -P /usr/include/notcurses/notcurses.h > notcurses.eh 
cigloo -gcc -macro notcurses.eh -o notcurses.sch 

gcc `pkg-config --cflags gtk4` -E -P /usr/include/gtk-4.0/gtk/gtk.h > gtk.eh 
cigloo -gcc -macro gtk.eh -o gtk.sch 

