### PR TITLE
Changes to the Bigloo C runtime to support C23 and GCC 15

### DIFF
--- a/api/gstreamer/src/Clib/bglgst.c
+++ b/api/gstreamer/src/Clib/bglgst.c
@@ -21,7 +21,7 @@
 /*---------------------------------------------------------------------*/
 /*    Imports                                                          */
 /*---------------------------------------------------------------------*/
-BGL_RUNTIME_DECL obj_t void_star_to_obj();
+BGL_RUNTIME_DECL obj_t void_star_to_obj(void*);
 extern obj_t bgl_gst_bin_elements_set( obj_t, obj_t );
 
 /*---------------------------------------------------------------------*/
@@ -473,12 +473,15 @@ bgl_gst_invoke_callbacks() {
    }
 }
 
+
+typedef obj_t (*constr_t)(void*, obj_t);
+
 /*---------------------------------------------------------------------*/
 /*    static obj_t                                                     */
 /*    gst_registry_list_to_obj ...                                     */
 /*---------------------------------------------------------------------*/
 static obj_t
-gst_registry_list_to_obj( GList *glist, obj_t (*constr)() ) {
+gst_registry_list_to_obj(GList *glist, constr_t constr) {
    obj_t res = BNIL;
    obj_t last = 0L;
    GList *gl = glist;
@@ -513,7 +516,7 @@ obj_t
 bgl_gst_registry_get_element_factory_list( GstRegistry *reg ) {
    return gst_registry_list_to_obj(
       gst_registry_get_feature_list( reg, GST_TYPE_ELEMENT_FACTORY ),
-      &bgl_gst_element_factory_new );
+      (constr_t)&bgl_gst_element_factory_new );
 }
 
 /*---------------------------------------------------------------------*/
@@ -533,7 +536,7 @@ obj_t
 bgl_gst_registry_get_feature_list_by_plugin( GstRegistry *reg, char *name ) {
    return gst_registry_list_to_obj(
       gst_registry_get_feature_list_by_plugin( reg, name ),
-      &gst_feature_to_obj );
+      (constr_t)&gst_feature_to_obj );
 }
 
 /*---------------------------------------------------------------------*/
@@ -544,7 +547,7 @@ obj_t
 bgl_gst_registry_get_plugin_list( GstRegistry *reg ) {
    return gst_registry_list_to_obj(
       gst_registry_get_plugin_list( reg ),
-      &bgl_gst_plugin_new );
+      (constr_t)&bgl_gst_plugin_new );
 }
 
 /*---------------------------------------------------------------------*/
@@ -1068,7 +1071,7 @@ bgl_gst_buffer_set_string( GstBuffer *buf, obj_t str )
 /*    bgl_gst_message_error_parser ...                                 */
 /*---------------------------------------------------------------------*/
 char *
-bgl_gst_message_error_parser( GstMessage *msg, void (*parser)() ) {
+bgl_gst_message_error_parser( GstMessage *msg, void (*parser)(GstMessage*, GError**, gchar**) ) {
    GError *err;
    char *debug;
    char *str;

--- a/api/gstreamer/src/Clib/bglgst.h
+++ b/api/gstreamer/src/Clib/bglgst.h
@@ -44,7 +44,7 @@ extern obj_t bgl_gst_static_pad_template_new( GstStaticPadTemplate * );
 /*---------------------------------------------------------------------*/
 extern bool_t bgl_gst_objectp( obj_t );
 extern obj_t bgl_gst_object_to_obj( GstObject *, obj_t );
-extern GstObject *bgl_gst_object_to_gstobject();
+extern GstObject *bgl_gst_object_to_gstobject(obj_t);
 extern obj_t bgl_closure_gcmark( obj_t );
 extern obj_t bgl_closure_gcunmark( obj_t );
 extern obj_t bgl_gst_lock();

--- a/api/gstreamer/src/Clib/bglgst_thread.c
+++ b/api/gstreamer/src/Clib/bglgst_thread.c
@@ -29,8 +29,8 @@
 extern void bglpth_thread_cleanup( void *arg );
 extern void bglpth_thread_env_create( void *thread, obj_t bglthread );
 extern void bglpth_thread_init( void *self, char *stack_bottom );
-extern obj_t bglpth_thread_thunk();
-void *bglpth_thread_new();
+extern obj_t bglpth_thread_thunk(void*);
+void *bglpth_thread_new(obj_t);
 
 /*---------------------------------------------------------------------*/
 /*    GRealThread                                                      */

--- a/api/gstreamer/src/Llib/gstobject.scm
+++ b/api/gstreamer/src/Llib/gstobject.scm
@@ -32,7 +32,7 @@
 
 	    (generic %gst-object-init ::gst-object)
 
-	    (%gst-object->gobject::$gst-object ::gst-object)
+	    (%gst-object->gobject::$gst-object ::obj)
 
 	    (%gst-object-ref! ::gst-object)
 	    (%gst-object-unref! ::gst-object)
@@ -71,7 +71,7 @@
 ;*---------------------------------------------------------------------*/
 ;*    %gst-object->gobject ...                                         */
 ;*---------------------------------------------------------------------*/
-(define (%gst-object->gobject o::gst-object)
+(define (%gst-object->gobject o::obj)
    (with-access::gst-object o ($builtin)
       $builtin))
 

--- a/api/libbacktrace/src/Clib/bglbacktrace.c
+++ b/api/libbacktrace/src/Clib/bglbacktrace.c
@@ -44,12 +44,11 @@ static int
 backtrace_foreach_cb(void *data, uintptr_t pc, const char *filename, int lineno, const char *function) {
    obj_t proc = (obj_t)data;
    
-   return PROCEDURE_ENTRY(proc)
+   return BGL_PROCEDURE_CALL3
       (proc,
        filename ? string_to_bstring((char *)filename) : BUNSPEC,
        BINT(lineno),
-       function ? string_to_bstring((char *)function) : BUNSPEC,
-       BEOA)
+       function ? string_to_bstring((char *)function) : BUNSPEC)
       != BFALSE;
 }
 

--- a/api/pthread/src/Posix/bglsetup.c
+++ b/api/pthread/src/Posix/bglsetup.c
@@ -63,7 +63,7 @@ bglpth_setup_gc() {
    extern void *GC_do_blocking();
 #endif
    
-   bgl_gc_do_blocking = (void *(*)())&GC_do_blocking;
+   bgl_gc_do_blocking = (void* (*)(void (*)(void*), void*))&GC_do_blocking;
 #endif
 
    GC_init();

--- a/api/sqlite/src/Posix/bglsqlite.c
+++ b/api/sqlite/src/Posix/bglsqlite.c
@@ -94,7 +94,8 @@ bgl_sqlite_exec(sqlite3 *db, char *str, obj_t odb) {
   obj_t result = BFALSE;
   int rc;
 
-  rc = sqlite3_exec(db, str, (int (*)())sqlite_callback_exec, &result, &msg);
+  rc = sqlite3_exec(db, str, (int (*)(void *, int, char **, char **))sqlite_callback_exec,
+                    &result, &msg);
 
   if (rc != SQLITE_OK) {
      char *buf = (char *)alloca(strlen(str) + 16);
@@ -457,7 +458,9 @@ bgl_sqlite_eval(sqlite3 *db, obj_t proc, char *str, obj_t odb) {
   obj_t result[] = { proc, BFALSE };
   int rc;
 
-  rc = sqlite3_exec(db, str, (int (*)())sqlite_callback_eval, result, &msg);
+  rc = sqlite3_exec(db, str,
+                    (int (*)(void *, int, char **, char **))sqlite_callback_eval,
+                    result, &msg);
 
   if (rc != SQLITE_OK) {
      char *buf = (char *)alloca(strlen(str) + 16);
@@ -501,7 +504,8 @@ bgl_sqlite_get(sqlite3 *db, obj_t proc, char *str, obj_t odb) {
   char *msg;
   int rc;
 
-  rc = sqlite3_exec(db, str, (int (*)())sqlite_callback_get, proc, &msg);
+  rc = sqlite3_exec(db, str, (int (*)(void *, int, char **, char **))sqlite_callback_get,
+                    proc, &msg);
 
   if (rc != SQLITE_OK && rc != SQLITE_ABORT) {
      char *buf = (char *)alloca(strlen(str) + strlen(msg) + 17);
@@ -543,7 +547,9 @@ bgl_sqlite_map(sqlite3 *db, obj_t proc, char *str, obj_t odb) {
   obj_t result[] = { proc, BNIL };
   int rc;
 
-  rc = sqlite3_exec(db, str, (int (*)())sqlite_callback_map, result, &msg);
+  rc = sqlite3_exec(db, str,
+                    (int (*)(void *, int, char **, char **))sqlite_callback_map,
+                    result, &msg);
 
   if (rc != SQLITE_OK) {
      char *buf = (char *)alloca(strlen(str) + 16);
@@ -588,7 +594,8 @@ bgl_sqlite_for_each(sqlite3 *db, obj_t proc, char *str, obj_t odb) {
   obj_t tmp[] = { proc, 0L };
   int rc;
 
-  rc = sqlite3_exec(db, str, (int (*)())sqlite_callback_for_each, tmp, &msg);
+  rc = sqlite3_exec(db, str, (int (*)(void *, int, char **, char **))sqlite_callback_for_each,
+                    tmp, &msg);
 
   if (rc != SQLITE_OK) {
      char *buf = (char *)alloca(strlen(str) + 16);

--- a/autoconf/ccoptim
+++ b/autoconf/ccoptim
@@ -100,7 +100,7 @@ EOF
 
 cat > $file1.c <<EOF
 #include <stdlib.h>
-extern int gcc3xxx_bug();
+extern int gcc3xxx_bug( int x );
 
 int foo( int x ) {
    return x + 1;

--- a/autoconf/dlopen
+++ b/autoconf/dlopen
@@ -54,9 +54,9 @@ fi
 #*    Test                                                             */
 #*---------------------------------------------------------------------*/
 cat > $file.c <<EOF
-extern void *dlopen();
-extern int dlclose();
-extern void *dlsym();
+extern void *dlopen(const char* filename, int flags);
+extern int dlclose(void* handle);
+extern void *dlsym(void* handle, char* symbol);
 
 int main( int argc, char *argv[] ) {
    void *handle = dlopen( "/dev/null", 0 );

--- a/autoconf/sendfile
+++ b/autoconf/sendfile
@@ -57,7 +57,8 @@ cat > $file.c <<EOF
 #include <errno.h>
 #include <signal.h>
 
-extern ssize_t sendfile();
+extern ssize_t sendfile(int out_fd, int in_fd, off_t* offset,
+                        size_t count);
 
 int main( int argc, char *argv[] ) {
    char buffer [50];

--- a/autoconf/stackdown
+++ b/autoconf/stackdown
@@ -53,29 +53,34 @@ rm -f $aout.exe 2> /dev/null
 #*    Test                                                             */
 #*---------------------------------------------------------------------*/
 cat > $file.c <<EOF
-#include <stdio.h> 
+#include <stdio.h>
+typedef void (*stack_dir_tracker)(long addr, void* t);
 
-void (*f)();
+stack_dir_tracker f; 
 
-void direction(long new_addr, void (*g)()) {
+void alt_direction(long new_addr, void* g) {
+     puts( "why are we here"); 
+}
+
+void direction(long new_addr, void* g) {
    static long *old_addr;
    static int flag = 0;
 
    if (!flag) {
      old_addr = &new_addr;
      flag++;
-     g(2, (void (*)())&printf);
+     ((stack_dir_tracker) g)(2, g);
    } else if (flag == 1) {
      flag++;
      (old_addr > &new_addr) ? puts("1") : puts("0");
    } else {
      flag++;
-     g(3,  (void (*)())&puts);;
+     ((stack_dir_tracker)g )(3,  &direction);;
    }
 }
 
 int main(int argc, char *argv[]) {
-   f = argc > 10 ? (void (*)())&puts : &direction;
+   f = argc > 10 ? &alt_direction : &direction;
    f(1, f);
 }
 EOF

--- a/autoconf/stacksize
+++ b/autoconf/stacksize
@@ -42,7 +42,7 @@ aout=$TMP/Xactest$USER
 #*---------------------------------------------------------------------*/
 #*    compile                                                          */
 #*---------------------------------------------------------------------*/
-compile="$CC $cflags $file.c -o $aout >/dev/null"
+compile="gcc $cflags $file.c -o $aout >/dev/null"
 
 #*---------------------------------------------------------------------*/
 #*    The test C file                                                  */
@@ -58,7 +58,7 @@ rm -f $aout.exe 2> /dev/null
 #*    Test                                                             */
 #*---------------------------------------------------------------------*/
 cat > $file.c <<EOF
-int (*fun)();
+int (*fun)(int x, int y);
 int glob;
 
 int foo( int x, int y ) {
@@ -99,7 +99,7 @@ if eval "$BUILDSH $compile"; then
    fi
 fi
 
-rm -f $aout
-rm -rf $aout*
+#rm -f $aout
+#rm -rf $aout*
 
 echo $status

--- a/bdb/blib/stat.c
+++ b/bdb/blib/stat.c
@@ -31,7 +31,7 @@
 extern long get_hash_number( char * );
 extern long get_hash_number_from_int( unsigned long );
 extern long bgl_types_number();
-extern obj_t create_vector();
+extern obj_t create_vector(long);
 
 /*---------------------------------------------------------------------*/
 /*    Exportations ...                                                 */

--- a/bde/bmem/lib/bmem.h
+++ b/bde/bmem/lib/bmem.h
@@ -50,7 +50,7 @@
 /*---------------------------------------------------------------------*/
 /*    Various types                                                    */
 /*---------------------------------------------------------------------*/
-typedef void *(*fun_t)();
+typedef void* fun_t;
 
 typedef struct gc_info {
    unsigned long number;
@@ -183,12 +183,12 @@ extern void *(*____GC_malloc)(size_t);
 extern void *(*____GC_realloc)(void *, size_t);
 extern void *(*____GC_malloc_atomic)(size_t);
 extern void *(*____GC_malloc_uncollectable)(size_t);
-extern void *(*____GC_add_gc_hook)(void (*)());
+extern void *(*____GC_add_gc_hook)(void (*)(int, long));
 extern BGL_LONGLONG_T (*____bgl_current_nanoseconds)();
 
 extern void (*____bgl_init_objects)();
 
-extern void (*____bgl_init_trace_register)();
+extern void (*____bgl_init_trace_register)(void (*i)(obj_t), obj_t (*g)(int), void (*w)(obj_t));
 extern obj_t (*____bgl_get_trace_stack)(int);
 
 extern void *(*____register_class)(void *, void *, void *,

--- a/bde/bmem/lib/init.c
+++ b/bde/bmem/lib/init.c
@@ -60,14 +60,14 @@ void *(*____GC_realloc)(void *, size_t) = 0;
 void *(*____GC_malloc_atomic)(size_t) = 0;
 void *(*____GC_malloc_uncollectable)(size_t) = 0;
 void (*____GC_gcollect)() = 0;
-void *(*____GC_add_gc_hook)(void (*)()) = 0;
+void *(*____GC_add_gc_hook)(void (*)(int, long)) = 0;
 char **____executable_name = 0;
 void *____command_line = 0;
 void (*____GC_reset_allocated_bytes)() = 0;
 BGL_LONGLONG_T (*____bgl_current_nanoseconds)() = 0;
 
 /* trace */
-void (*____bgl_init_trace_register)(void (*i)(), obj_t (*g)(int), void (*w)(obj_t));
+void (*____bgl_init_trace_register)(void (*i)(obj_t), obj_t (*g)(int), void (*w)(obj_t));
 obj_t (*____bgl_get_trace_stack)(int);
 
 /* thread */
@@ -356,9 +356,9 @@ bglpth_setup_bmem() {
 
    ____bglthread_setup_bmem =(void(*)())get_function(hdl, "bglpth_setup_bmem");
    ____pthread_getspecific = get_function(hdl, "bglpth_pthread_getspecific");
-   ____pthread_setspecific =(int(*)())get_function(hdl, "bglpth_pthread_setspecific");
-   ____pthread_key_create =(int(*)())get_function(hdl, "bglpth_pthread_key_create");
-   ____pthread_mutex_init =(int(*)())get_function(hdl, "bglpth_pthread_mutex_init");
+   ____pthread_setspecific =(int (*)(pthread_key_t,  void *))get_function(hdl, "bglpth_pthread_setspecific");
+   ____pthread_key_create =(int (*)(pthread_key_t *, void (*)(void *)))get_function(hdl, "bglpth_pthread_key_create");
+   ____pthread_mutex_init =(int (*)(pthread_mutex_t *, void *))get_function(hdl, "bglpth_pthread_mutex_init");
 
    if (____pthread_key_create(&bmem_key, 0L)) {
       FAIL(IDENT, "Can't get thread key", "bmem_key");
@@ -473,12 +473,12 @@ bmem_init_inner() {
    ____executable_name = get_variable(hdl, "executable_name");
    ____command_line = get_variable(hdl, "command_line");
    ____bgl_init_objects =(void(*)())get_function(hdl, "bgl_init_objects");
-   ____get_hash_power_number =(long(*)())get_function(hdl, "get_hash_power_number");
-   ____get_hash_power_number_len =(long(*)())get_function(hdl, "get_hash_power_number_len");
+   ____get_hash_power_number =(long int (*)(char *, long unsigned int))get_function(hdl, "get_hash_power_number");
+   ____get_hash_power_number_len =(long int (*)(char *, long unsigned int,  long int))get_function(hdl, "get_hash_power_number_len");
    ____bgl_get_symtab = get_function(hdl, "bgl_get_symtab");
    ____bgl_current_nanoseconds =(BGL_LONGLONG_T(*)())get_function(hdl, "bgl_current_nanoseconds");
 
-   ____bgl_init_trace_register =(void(*)())get_function(hdl, "bgl_init_trace_register");
+   ____bgl_init_trace_register =(void (*)(void (*)(obj_t), obj_t (*)(int), void (*)(obj_t)))get_function(hdl, "bgl_init_trace_register");
    
    /* class */
    ____register_class = get_function(hdl, "BGl_registerzd2classz12zc0zz__objectz00");

--- a/bde/bmem/lib/wrapper.c
+++ b/bde/bmem/lib/wrapper.c
@@ -18,72 +18,82 @@
 #include <wrapper.h>
 
 /* pair */
-void *(*____make_pair)() = 0L;
+void *(*____make_pair)(obj_t, obj_t) = 0L;
 
 /* vectors */
-void *(*____create_vector)() = 0L;
-void *(*____create_vector_uncollectable)() = 0L;
+void *(*____create_vector)(int) = 0L;
+void *(*____create_vector_uncollectable)(int) = 0L;
 
 /* procedures */
-void *(*____make_fx_procedure)() = 0L;
-void *(*____make_va_procedure)() = 0L;
+void *(*____make_fx_procedure)(function_t, int,  int) = 0L;
+void *(*____make_va_procedure)(function_t , int,  int) = 0L;
 
 /* internals */
 void *(*____make_dynamic_env)() = 0L;
 
 /* cell */
-void *(*____make_cell)() = 0L;
+obj_t (*____make_cell)(obj_t) = 0L;
 
 /* strings */
-void *(*____string_to_bstring_len)() = 0L;
-void *(*____string_to_bstring)() = 0L;
-void *(*____make_string)() = 0L;
-void *(*____make_string_sans_fill)() = 0L;
-void *(*____string_append)() = 0L;
-void *(*____c_substring)() = 0L;
+void *(*____string_to_bstring_len)(char*, int) = 0L;
+void *(*____string_to_bstring)(char*) = 0L;
+void *(*____make_string)(long, unsigned char) = 0L;
+void *(*____make_string_sans_fill)(long) = 0L;
+void *(*____string_append)(obj_t, obj_t) = 0L;
+void *(*____c_substring)(obj_t, long, long) = 0L;
 
-void *(*____make_ucs2_string)() = 0L;
+void *(*____make_ucs2_string)(int, ucs2_t) = 0L;
    
 /* symbol */
-void *(*____bstring_to_symbol)() = 0L;
+void *(*____bstring_to_symbol)(obj_t) = 0L;
 
 /* keyword */
-void *(*____bstring_to_keyword)() = 0L;
+void *(*____bstring_to_keyword)(obj_t) = 0L;
 
 /* real */
 #if (BGL_TAGGING != BGL_TAGGING_NAN) && (BGL_TAGGING != BGL_TAGGING_NUN)
-void *(*____make_real)() = 0L;
+void *(*____make_real)(double) = 0L;
 #endif
 
 /* threads & locks */
-void *(*____bgl_make_mutex)() = 0L;
-void *(*____bgl_make_spinlock)() = 0L;
+void *(*____bgl_make_mutex)(obj_t) = 0L;
+void *(*____bgl_make_spinlock)(obj_t) = 0L;
 
 /* ports */
-void *(*____bgl_open_output_string)() = 0L;
-void *(*____bgl_make_output_port)() = 0L;
-void *(*____bgl_make_input_port)() = 0L;
+void *(*____bgl_open_output_string)(obj_t) = 0L;
+void *(*____bgl_make_output_port)(obj_t, bgl_stream_t, int,
+                                  obj_t, obj_t,
+                                  ssize_t (*write)(void *, void *, size_t),
+                                  long (*seek)(void *, long, int),
+                                  int (*close)(void*)) = 0L;
+void *(*____bgl_make_input_port)(obj_t, FILE*, obj_t, obj_t) = 0L;
 
 /* classes */
-void *(*____bgl_make_class)() = 0L;
-void *(*____create_struct)() = 0L;
+void *(*____bgl_make_class)(obj_t, obj_t, long, long,
+                            obj_t, obj_t,
+                            obj_t, long,
+                            obj_t, obj_t,
+                            obj_t, obj_t, obj_t, obj_t, obj_t,
+                            long, 
+                            obj_t) = 0L;
+void *(*____create_struct)(obj_t key, int len) = 0L;
 
 /* bignums */
-void *(*____bgl_bignum_add)() = 0L;
-void *(*____bgl_bignum_sub)() = 0L;
-void *(*____bgl_bignum_mul)() = 0L;
-void *(*____bgl_bignum_div)() = 0L;
-void *(*____bgl_bignum_expt)() = 0L;
-void *(*____bgl_bignum_quotient)() = 0L;
-void *(*____bgl_bignum_remainder)() = 0L;
-void *(*____bgl_bignum_or)() = 0L;
-void *(*____bgl_bignum_xor)() = 0L;
-void *(*____bgl_bignum_and)() = 0L;
-void *(*____bgl_bignum_mask)() = 0L;
-void *(*____bgl_bignum_not)() = 0L;
-void *(*____bgl_long_to_bignum)() = 0L;
-void *(*____bgl_bignum_lsh)() = 0L;
-void *(*____bgl_bignum_rsh)() = 0L;
+void *(*____bgl_bignum_add)(obj_t, obj_t) = 0L;
+void *(*____bgl_bignum_sub)(obj_t, obj_t) = 0L;
+void *(*____bgl_bignum_mul)(obj_t, obj_t) = 0L;
+void *(*____bgl_bignum_div)(obj_t, obj_t) = 0L;
+void *(*____bgl_bignum_expt)(obj_t, obj_t) = 0L;
+void *(*____bgl_bignum_quotient)(obj_t, obj_t) = 0L;
+void *(*____bgl_bignum_remainder)(obj_t, obj_t) = 0L;
+void *(*____bgl_bignum_or)(obj_t, obj_t) = 0L;
+void *(*____bgl_bignum_xor)(obj_t, obj_t) = 0L;
+void *(*____bgl_bignum_and)(obj_t, obj_t) = 0L;
+void *(*____bgl_bignum_mask)(obj_t, long) = 0L;
+void *(*____bgl_bignum_not)(obj_t) = 0L;
+void *(*____bgl_long_to_bignum)(long) = 0L;
+void *(*____bgl_bignum_lsh)(obj_t, long) = 0L;
+void *(*____bgl_bignum_rsh)(obj_t, long) = 0L;
    
 /*---------------------------------------------------------------------*/
 /*    void                                                             */
@@ -193,12 +203,12 @@ WRAP(create_vector_uncollectable,
 /* procedure */
 WRAP(make_fx_procedure,
      PROCEDURE_TYPE_NUM,
-     (obj_t (*e)(), int a, int s),
-     ((void *(*)())e, a, s));
+     (function_t e, int a, int s),
+     ((function_t)e, a, s));
 WRAP(make_va_procedure,
      PROCEDURE_TYPE_NUM,
-     (obj_t (*e)(), int a, int s),
-     ((void *(*)())e, a, s));
+     (function_t e, int a, int s),
+     ((function_t)e, a, s));
 
 /* internal */
 WRAP(make_dynamic_env,
@@ -281,7 +291,7 @@ WRAP(bgl_open_output_string,
 WRAP(bgl_make_output_port,
      OUTPUT_PORT_TYPE_NUM,
      (obj_t n, bgl_stream_t s, int t, obj_t k, obj_t b,
-      ssize_t (*write)(), long (*seek)(), int (*close)()),
+      ssize_t (*write)(void*, void*, size_t), long (*seek)(void*, long, int), int (*close)(void*)),
      (n, s, t, k, b, write, seek, close));
 WRAP(bgl_make_input_port,
      INPUT_PORT_TYPE_NUM,

--- a/bde/bmem/lib/wrapper.h
+++ b/bde/bmem/lib/wrapper.h
@@ -19,7 +19,7 @@ extern void bmem_init_wrapper(void *);
 extern void *(*____create_vector)(int);
 extern void *(*____create_vector_uncollectable)(int);
 
-extern void *(*____make_fx_procedure)(void *(*)(), int, int);
-extern void *(*____make_va_procedure)(void *(*)(), int, int);
+extern void *(*____make_fx_procedure)(function_t, int, int);
+extern void *(*____make_va_procedure)(function_t, int, int);
 
 #endif

--- a/runtime/Clib/callcc.c
+++ b/runtime/Clib/callcc.c
@@ -24,7 +24,7 @@ extern int flush_regs_in_stack();
 /*---------------------------------------------------------------------*/
 extern long glob_dummy;
 
-extern obj_t make_fx_procedure(obj_t (*)(), int, int);
+extern obj_t make_fx_procedure(function_t, int, int);
 extern obj_t c_constant_string_to_string(char *);
 
 static obj_t callcc_restore_stack(obj_t, obj_t, char **);

--- a/runtime/Clib/ccontrol.c
+++ b/runtime/Clib/ccontrol.c
@@ -57,7 +57,7 @@ bgl_dup_procedure(obj_t proc) {
 /*    bgl_init_fx_procedure ...                                        */
 /*---------------------------------------------------------------------*/
 obj_t
-bgl_init_fx_procedure(obj_t proc, obj_t (*entry)(), int arity, int size) {
+bgl_init_fx_procedure(obj_t proc, function_t entry, int arity, int size) {
    if (size >= BGL_HEADER_MAX_SIZE) {
       C_FAILURE("make-fx-procedure", "Environment to large", BINT(size));
    } else {

--- a/runtime/Clib/cprocess.c
+++ b/runtime/Clib/cprocess.c
@@ -653,9 +653,9 @@ c_run_process(obj_t bhost, obj_t bfork, obj_t bwaiting,
 					      BGL_STREAM_TYPE_FD,
 					      KINDOF_PROCPIPE,
 					      make_string_sans_fill(80),
-					      bgl_syswrite,
-					      (long (*)())lseek,
-					      close);
+                                             (ssize_t (*)(void*, void*, size_t))bgl_syswrite,
+                                             (long (*)(void*, long, int))lseek,
+                                             (int (*)(void*))close);
 					      
 		  else
 		     PROCESS(proc).stream[ i ] =

--- a/runtime/Clib/csocket.c
+++ b/runtime/Clib/csocket.c
@@ -1410,13 +1410,13 @@ set_socket_io_ports(int s, obj_t sock, const char *who, obj_t inb, obj_t outb) {
 
    /* Create output port */
    SOCKET(sock).output = bgl_make_output_port(sock,
-						 (bgl_stream_t)t,
-						 BGL_STREAM_TYPE_FD,
-						 KINDOF_SOCKET,
-						 outb,
-						 bgl_syswrite,
-						 (long (*)())&lseek,
-						 &bgl_sclose_wd);
+                                              (bgl_stream_t)t,
+                                              BGL_STREAM_TYPE_FD,
+                                              KINDOF_SOCKET,
+                                              outb,
+                                              (ssize_t (*)(void*, void*, size_t))bgl_syswrite,
+                                              (long (*)(void*, long, int))&lseek,
+                                              (int (*)(void*)) &bgl_sclose_wd);
    OUTPUT_PORT(SOCKET(sock).output).sysflush = (obj_t (*)(void *))&bgl_socket_flush;
       
    if (STRING_LENGTH(outb) <= 1)
@@ -2884,9 +2884,9 @@ bgl_make_datagram_client_socket(obj_t hostname, int port, bool_t broadcast, obj_
 			    BGL_STREAM_TYPE_CHANNEL,
 			    KINDOF_SOCKET,
 			    make_string_sans_fill(0),
-			    &datagram_socket_write,
+                           (ssize_t (*)(void*, void*, size_t))&datagram_socket_write,
 			    0L,
-			    &bgl_sclose_wd);
+                           (int (*)(void*))&bgl_sclose_wd);
    OUTPUT_PORT(a_socket->datagram_socket.port).sysflush = (obj_t (*)(void *))&bgl_socket_flush;
    OUTPUT_PORT(a_socket->datagram_socket.port).bufmode = BGL_IONB;
    

--- a/runtime/Clib/cthread.c
+++ b/runtime/Clib/cthread.c
@@ -73,7 +73,7 @@ BGL_RUNTIME_DEF obj_t (*bgl_create_spinlock)(obj_t) = &bgl_create_mutex_default;
 BGL_RUNTIME_DEF void (*bgl_gc_start_blocking)(void) = &bgl_act0_default;
 BGL_RUNTIME_DEF void (*bgl_gc_stop_blocking)(void) = &bgl_act0_default;
 
-BGL_RUNTIME_DEF void *(*bgl_gc_do_blocking)(void (*fun)(), void *) = &bgl_gc_do_blocking_default;
+BGL_RUNTIME_DEF void *(*bgl_gc_do_blocking)(void (*fun)(void*), void *) = &bgl_gc_do_blocking_default;
 
 BGL_RUNTIME_DEF obj_t (*bgl_multithread_dynamic_denv)() = &denv_get;
 

--- a/runtime/Clib/ctrace.c
+++ b/runtime/Clib/ctrace.c
@@ -27,7 +27,7 @@ BGL_RUNTIME_DEF void (*bgl_walk_trace_stack)(obj_t) = &default_walk_trace_stack;
 /*    bgl_init_trace_register ...                                      */
 /*---------------------------------------------------------------------*/
 void
-bgl_init_trace_register(void (*i)(), obj_t (*g)(int), void (*w)(obj_t)) {
+bgl_init_trace_register(void (*i)(obj_t), obj_t (*g)(int), void (*w)(obj_t)) {
    bgl_init_trace = i;
 
    bgl_get_trace_stack = (g ? g : no_get_trace_stack);

--- a/runtime/Clib/inline_alloc.c
+++ b/runtime/Clib/inline_alloc.c
@@ -46,7 +46,7 @@ gcollect_verbose(unsigned long heapsz, unsigned long use) {
 GC_API void
 bgl_gc_verbose_set(bool_t verbose) {
 #if((BGL_GC == BGL_BOEHM_GC) && BGL_GC_CUSTOM)
-   extern void GC_add_gc_hook(void (*f)());
+  extern void GC_add_gc_hook(void (*f)(unsigned long, unsigned long));
    
    if (verbose) {
       fprintf(stderr, "bgl_gc_verbose on...\n");

--- a/runtime/Include/bigloo.h
+++ b/runtime/Include/bigloo.h
@@ -637,6 +637,13 @@ struct bgl_dframe {
    struct bgl_dframe *link;
 };
 
+/* function type */
+#if !BGL_STRICT_STDC
+typedef obj_t (*function_t)();
+#else 
+typedef void* function_t;
+#endif
+
 /* bigloo polymorphic type */
 union scmobj {
    /* integer */
@@ -663,8 +670,8 @@ union scmobj {
    /* procedure (closures) */
    struct procedure {
       header_t header;    
-      union scmobj *(*entry)();
-      union scmobj *(*va_entry)();
+      function_t entry;
+     function_t va_entry;
       union scmobj *attr;
       int arity;
       union scmobj *obj0;
@@ -672,7 +679,7 @@ union scmobj {
 
    /* light procedures (results of the CFA optimization) */
    struct procedure_light {
-      union scmobj *(*entry)();
+      function_t entry;
       union scmobj  *obj0;
    } procedure_light;
 
@@ -1204,8 +1211,7 @@ union scmobj {
    struct bgl_semaphore semaphore;
 };
 
-/* function type */
-typedef obj_t (*function_t)();
+
 
 /*---------------------------------------------------------------------*/
 /*    The garbage collector                                            */
@@ -2804,7 +2810,7 @@ BGL_RUNTIME_DECL obj_t bgl_make_buint32(uint32_t);
 BGL_RUNTIME_DECL obj_t bgl_make_bint64(int64_t);
 BGL_RUNTIME_DECL obj_t bgl_make_buint64(uint64_t);
 
-BGL_RUNTIME_DECL obj_t bgl_make_output_port(obj_t, bgl_stream_t, int, obj_t, obj_t, ssize_t (*)(), long (*)(), int (*)());
+BGL_RUNTIME_DECL obj_t bgl_make_output_port(obj_t, bgl_stream_t,  int,  obj_t, obj_t, ssize_t (*)(void *, void *, size_t), long int (*)(void *, long int,  int), int (*)(void*));
 BGL_RUNTIME_DECL void bgl_output_port_buffer_set(obj_t, obj_t);   
 BGL_RUNTIME_DECL obj_t bgl_close_output_port(obj_t);
 BGL_RUNTIME_DECL obj_t get_output_string(obj_t);
@@ -2902,7 +2908,7 @@ BGL_RUNTIME_DECL void (*bgl_gc_stop_blocking)(void);
 #endif
    
 #if (BGL_GC_HAVE_DO_BLOCKING)
-BGL_RUNTIME_DECL void *(*bgl_gc_do_blocking)(void (*fun)(), void *);
+BGL_RUNTIME_DECL void *(*bgl_gc_do_blocking)(void (*fun)(void*), void *);
 #endif
    
 BGL_RUNTIME_DECL obj_t bgl_make_client_socket(obj_t, int, int, obj_t, obj_t, obj_t);
@@ -2916,7 +2922,7 @@ BGL_RUNTIME_DECL obj_t bgl_datagram_socket_hostname(obj_t);
 BGL_RUNTIME_DECL obj_t bgl_getsockopt(obj_t, obj_t);
 BGL_RUNTIME_DECL obj_t bgl_setsockopt(obj_t, obj_t, obj_t);
 
-BGL_RUNTIME_DECL void bgl_init_trace_register(void (*i)(), obj_t (*g)(int), void (*w)(obj_t));
+BGL_RUNTIME_DECL void bgl_init_trace_register(void (*)(obj_t), obj_t(*)(int), void (*)(obj_t));
 BGL_RUNTIME_DECL void (*bgl_init_trace)(obj_t);
 BGL_RUNTIME_DECL obj_t (*bgl_get_trace_stack)(int);
 


### PR DESCRIPTION
Most changes are due to C23 which GCC 15 defaults to changing the meaning of function declarations without parameters (e.g., int foo()). In C17 and earlier versions of C, this indicates that there is no information about the number and type of the arguments required by the function, requiring the developer to know the correct arguments but not restricting what arguments may be passed to the function. In C23, a function with empty parameters indicates a function takes no arguments. The Bigloo C runtime relied on this in a number of places. To compile under C23 and GCC 15, we replaced such constructs. This largely entailed the addition of proper function declarations and updating autoconf scripts that relied on the feature. It also means that C23 support requires BGL_STRICT_STDC be true.

The changes have been successfully tested with GCC 15, GCC 14, and clang 19. Only GCC 15 defaults to the C23 standard.