### PR TITLE
Fix typo in name of BGL_FAST_REALSP for jvm

### DIFF
--- a/runtime/Jlib/foreign.java
+++ b/runtime/Jlib/foreign.java
@@ -1891,7 +1891,7 @@ public final class foreign
 	 return (o instanceof real);
       }
 
-   public static boolean BGL_FAST_REALP(Object o, Object p)
+   public static boolean BGL_FAST_REALSP(Object o, Object p)
       {
 	 return (o instanceof real) && (p instanceof real);
       }


### PR DESCRIPTION
BGL_FAST_REALSP was incorrectly named BGL_FAST_REALP for the jvm backend.