### PR TITLE
add support for periods in xml attribute names

### DIFF
--- a/api/web/src/Llib/xml.scm
+++ b/api/web/src/Llib/xml.scm
@@ -245,7 +245,7 @@
 ;*    attribute-grammar ...                                            */
 ;*---------------------------------------------------------------------*/
 (define attribute-grammar
-   (regular-grammar ((id (: (in ("azAZ") "_") (* (in ("azAZ09") ":_-"))))
+   (regular-grammar ((id (: (in ("azAZ") "_") (* (in ("azAZ09") ":_-."))))
 		     tag
 		     strict
 		     decoder)


### PR DESCRIPTION
This came up when parsing graphml files, which have attribute names such as attr.name and attr.type.