### PR TITLE
Make the test suite fail if individual tests fail

### DIFF
--- a/api/text/recette/recette.scm
+++ b/api/text/recette/recette.scm
@@ -159,4 +159,5 @@
 		 (format " ~a succeeded\n ~a failed ~a"
 			 *success*
 			 (length *failure*)
-			 (reverse *failure*))))))
+			 (reverse *failure*))))
+      (exit (length *failure*))))


### PR DESCRIPTION
This makes the test suite exit with a nonzero exit status if any tests fail, which is useful for automating checks that all tests passed.