### PR TITLE
Silence gcc buffer overflow warning

### DIFF
--- a/runtime/Clib/csocket.c
+++ b/runtime/Clib/csocket.c
@@ -2910,7 +2910,7 @@ bgl_make_datagram_server_socket(int portnum, obj_t family) {
    int s;
    struct addrinfo hints, *servinfo, *p;
    int rv;
-   char service[ 10 ];
+   char service[ 12 ];
    obj_t sock, buf, inb, iport;
    FILE *fs;
    int fam = bgl_symbol_to_family(family);


### PR DESCRIPTION
GCC sees that an int will be written into `service` and knows that writing -2147483647 takes 12 bytes, so it warns that the `sprintf` call may overflow the 10 byte buffer.  We know that port numbers don't cover the entire range of values of the `int` type, so the code is not really wrong.  This patch is purely to make gcc be quiet.

Note that on modern CPU architectures, either 12 or 16 bytes will be allocated anyway, for alignment reasons, so this change doesn't increase stack usage.