### PR TITLE
gmtoff: adjust variable type

### DIFF
--- a/autoconf/gmtoff
+++ b/autoconf/gmtoff
@@ -55,7 +55,7 @@ cat > $file.c <<EOF
 #include <sys/time.h>
 
 int main( int argc, char *argv[] ) {
-   long s = time( 0 );
+   time_t s = time( 0 );
    struct tm *tm = localtime( &s );
    
    return tm->tm_gmtoff - tm->tm_gmtoff;


### PR DESCRIPTION
The problem is that the incorrect type will lead to the result 1 (in gcc-13 and older) and to the result 0 (in gcc-14 and newer). Tested in timezone +01:00.