### PR TITLE
Fix to correct the handling of dsssl in generic functions

### DIFF
--- a/comptime/Ast/glo_def.scm
+++ b/comptime/Ast/glo_def.scm
@@ -279,7 +279,9 @@
        (eq? old new)
        (and sub?
 	    (or (type-subclass? new old)
-		(and (tclass? new) (eq? old *obj*))))))
+		;; we also have a compatible type when the old type is
+		;; explicitly *obj* or *_* and the new type is a class
+		(and (tclass? new) (or (eq? old *obj*) (eq? old *_*)))))))
 
 ;*---------------------------------------------------------------------*/
 ;*    mismatch-error ...                                               */
@@ -334,7 +336,10 @@
 		    src
 		    "(incompatible function type result)")
 		 #f)
-		((let loop ((locals locals)
+                ;; we only look at the locals representing required args
+                ;; and skip the locals introduced by dsssl keywords 
+		((let loop ((locals (take locals
+                                       (absfx (sfun-arity generic-value))))
 			    (types  (map (lambda (a)
 					    (cond
 					       ((local? a)

--- a/comptime/Ast/unit.scm
+++ b/comptime/Ast/unit.scm
@@ -698,24 +698,33 @@
 		   res)))))))
 
 ;*---------------------------------------------------------------------*/
+;*    parse-fun-key-args ...                                           */
+;*---------------------------------------------------------------------*/
+(define (parse-fun-key-args args src loc)
+   (append (args->locals (dsssl-before-dsssl args) src loc)
+	   (args->locals (map car (dsssl-keys args)) src loc)))
+
+;*---------------------------------------------------------------------*/
+;*    args->locals ...                                                 */
+;*    -------------------------------------------------------------    */
+;*    Create local variables from a list of formal identifiers.        */
+;*---------------------------------------------------------------------*/
+(define (args->locals args src loc)
+   (map (lambda (a)
+	   (let* ((pid (check-id (parse-id a loc) src))
+		  (id (car pid))
+		  (type (cdr pid)))
+	      (if (user-symbol? id)
+		  (make-user-local-svar id type)
+		  (make-local-svar id type))))
+      args))
+
+;*---------------------------------------------------------------------*/
 ;*    parse-fun-opt-args ...                                           */
 ;*---------------------------------------------------------------------*/
 (define (parse-fun-opt-args args src loc)
-   (append (map (lambda (a)
-		   (let* ((pid (check-id (parse-id a loc) src))
-			  (id (car pid))
-			  (type (cdr pid)))
-		      (if (user-symbol? id)
-			  (make-user-local-svar id type)
-			  (make-local-svar id type))))
-	      (dsssl-before-dsssl args))
-      (map (lambda (o)
-	      (let* ((a (car o))
-		     (pid (check-id (parse-id a loc) src))
-		     (id (car pid))
-		     (type (cdr pid)))
-		 (make-user-local-svar id type)))
-	 (dsssl-optionals args))))
+   (append (args->locals (dsssl-before-dsssl args) src loc)
+      (args->locals (map car (dsssl-optionals args)) src loc)))
    
 ;*---------------------------------------------------------------------*/
 ;*    make-sfun-noopt-definition ...                                   */
@@ -836,10 +845,17 @@
 	     (find-location src))
 	  (list #unspecified))
        (let* ((loc (find-location src))
-	      (locals (if (and (dsssl-prototype? args)
+	      (keys (and (dsssl-prototype? args) (dsssl-keys args)))
+	      (locals (cond
+			 ((and (dsssl-prototype? args)
 			       (pair? (dsssl-optionals args)))
-			  (parse-fun-opt-args args src loc)
-			  (parse-fun-args args src loc)))
+			  (parse-fun-opt-args args src loc))
+			 ((pair? keys)
+                          ;; Key arguments become positional arguments appended to
+                          ;; the existing required arguments
+			  (parse-fun-key-args args src loc))
+			 (else
+			  (parse-fun-args args src loc))))
 	      (pid (check-id (parse-id id loc) src))
 	      (name (gensym (car pid)))
 	      (type (cdr pid))
@@ -847,7 +863,8 @@
 	      (generic (def-global-sfun! id args locals module 'sgfun src 'now gbody))
 	      ;;(def `(labels ((,name ,(typed-args args generic)
 	      (def `(labels ((,name ,(if (and (dsssl-prototype? args)
-					      (pair? (dsssl-optionals args)))
+					      (or (pair? (dsssl-optionals args))
+						  (pair? keys)))
 					 (map local-id locals)
 					 (typed-args args generic))
 				;; use labels instead of a plain lambda expr
@@ -911,6 +928,9 @@
        (make-method-no-dsssl-body ident args locals body src))
       ((dsssl-optional-only-prototype? args)
        (let ((locals (parse-fun-opt-args args src loc)))
+	  (make-method-no-dsssl-body ident (map local-id locals) locals body src)))
+      ((dsssl-key-only-prototype? args)
+       (let ((locals (parse-fun-key-args args src loc)))
 	  (make-method-no-dsssl-body ident (map local-id locals) locals body src)))
       (else
        (make-method-dsssl-body ident args locals body src))))

--- a/recette/dsssl.scm
+++ b/recette/dsssl.scm
@@ -271,6 +271,52 @@
 (define (dsssl-bug #!key (foo::bool #t))
    foo)
 
+
+(define-class dsssl-test)
+
+(define-generic (do-w/optional a::obj #!optional (b 5))
+   (list 'default b))
+
+(define-method (do-w/optional a::dsssl-test #!optional (b 5))
+   (list 'method b))
+
+(define-generic (do-w/key a #!key (k 5))
+   (list 'default k))
+
+(define-method (do-w/key a::dsssl-test #!key (k 5))
+   (list 'method k))
+
+(define-generic (do-w/rest a::obj #!rest r)
+   (list 'default r))
+
+(define-method (do-w/rest a::dsssl-test #!rest r)
+   (list 'method r))
+
+(define-generic (do-w/opt+key a::obj #!optional (b 1) #!key (k 2))
+   (list 'default b k))
+
+(define-method (do-w/opt+key a::dsssl-test #!optional (b 1) #!key (k 2))
+   (list 'method b k))
+
+(define-generic (do-w/opt+rest a::obj #!optional (b 1) #!rest r)
+   (list 'default b r))
+
+(define-method (do-w/opt+rest a::dsssl-test #!optional (b 1) #!rest r)
+   (list 'method b r))
+
+(define-generic (do-w/key+rest a #!key (k 1) #!rest r)
+   (list 'default k r))
+
+(define-method (do-w/key+rest a::dsssl-test #!key (k 1) #!rest r)
+   (list 'method k r))
+
+(define-generic (do-w/all3 a::obj #!optional (b 1) #!key (k 2) #!rest r)
+   (list 'default b k r))
+
+(define-method (do-w/all3 a::dsssl-test #!optional (b 1) #!key (k 2) #!rest r)
+   (list 'method b k r))
+
+
 ;*---------------------------------------------------------------------*/
 ;*    test-dsssl ...                                                   */
 ;*---------------------------------------------------------------------*/
@@ -526,5 +572,49 @@
    (test "dssss11.2" (apply dsssl11 '(3 4 5 i: 6 i: 7 8 9))
 	 '(3 4 5 i: 6 j: 1 (8 9)))
    (test "dssss11.3" ((cadr (list dsssl9 dsssl11)) 3 4 5 i: 6 i: 7 8 9)
-		      '(3 4 5 i: 6 j: 1 (8 9))))
-     
+		      '(3 4 5 i: 6 j: 1 (8 9)))
+      ;; generic with #!optional
+   (test "generic/optional default" (do-w/optional 3) '(default 5))
+   (test "generic/optional value" (do-w/optional 3 10) '(default 10))
+   (test "generic/optional method default"
+	 (do-w/optional (instantiate::dsssl-test)) '(method 5))
+   (test "generic/optional method value"
+	 (do-w/optional (instantiate::dsssl-test) 10) '(method 10))
+   ;; generic with #!key
+   (test "generic/key default" (do-w/key 3) '(default 5))
+   (test "generic/key value" (do-w/key 3 k: 10) '(default 10))
+   (test "generic/key method default"
+	 (do-w/key (instantiate::dsssl-test)) '(method 5))
+   (test "generic/key method value"
+	 (do-w/key (instantiate::dsssl-test) k: 10) '(method 10))
+   ;; generic with #!rest
+   (test "generic/rest empty" (do-w/rest 3) '(default ()))
+   (test "generic/rest values" (do-w/rest 3 4 5) '(default (4 5)))
+   (test "generic/rest method empty"
+	 (do-w/rest (instantiate::dsssl-test)) '(method ()))
+   (test "generic/rest method values"
+	 (do-w/rest (instantiate::dsssl-test) 4 5) '(method (4 5)))
+   ;; generic with #!optional + #!key combined
+   (test "generic/opt+key defaults" (do-w/opt+key 3) '(default 1 2))
+   (test "generic/opt+key opt value" (do-w/opt+key 3 7) '(default 7 2))
+   (test "generic/opt+key key value" (do-w/opt+key 3 k: 9) '(default 1 9))
+   (test "generic/opt+key both" (do-w/opt+key 3 7 k: 9) '(default 7 9))
+   (test "generic/opt+key method defaults"
+	 (do-w/opt+key (instantiate::dsssl-test)) '(method 1 2))
+   (test "generic/opt+key method both"
+	 (do-w/opt+key (instantiate::dsssl-test) 7 k: 9) '(method 7 9))
+   ;; generic with #!optional + #!rest combined
+   (test "generic/opt+rest defaults" (do-w/opt+rest 3) '(default 1 ()))
+   (test "generic/opt+rest values" (do-w/opt+rest 3 10 20 30) '(default 10 (20 30)))
+   (test "generic/opt+rest method"
+	 (do-w/opt+rest (instantiate::dsssl-test) 10 20) '(method 10 (20)))
+   ;; generic with #!key + #!rest combined
+   (test "generic/key+rest defaults" (do-w/key+rest 3) '(default 1 ()))
+   (test "generic/key+rest value" (do-w/key+rest 3 k: 10) '(default 10 ()))
+   (test "generic/key+rest method"
+	 (do-w/key+rest (instantiate::dsssl-test) k: 10) '(method 10 ()))
+   ;; generic with #!optional + #!key + #!rest combined
+   (test "generic/all3 defaults" (do-w/all3 3) '(default 1 2 ()))
+   (test "generic/all3 values" (do-w/all3 3 10 k: 20) '(default 10 20 ()))
+   (test "generic/all3 method"
+	 (do-w/all3 (instantiate::dsssl-test) 10 k: 20) '(method 10 20 ())))


### PR DESCRIPTION
Previously, defining generic functions with DSSSL arguments produced compile-time and runtime errors.

1. The check-method-definition compared all method locals (including DSSSL parameters) against the generic's required argument types, causing "incompatible formal type" errors. We fixed by limiting comparison to required arguments only.

2. compatible-type? rejected methods specializing an untyped generic parameter (type *_*) to a class type. We fix by accepting *_* as compatible with class types alongside *obj*.

3. Generic functions with #!key arguments failed at runtime because the dispatch function extracted key values but methods expected raw keyword argument lists. We fixed by treating #!key generics like #!optional: the dispatch function parses keywords, and everything downstream receives extracted values as positional parameters.