### PR TITLE
Correct type of bgl_bignum_to_string 2nd parameter

### DIFF
--- a/runtime/Unsafe/bignumber.scm
+++ b/runtime/Unsafe/bignumber.scm
@@ -132,7 +132,7 @@
 	    "GCD_BIGNUM")
 	 (method static $lcmbx::bignum (::bignum ::bignum)
 	    "LCM_BIGNUM")
-	 (method static $bignum->string::string (::bignum ::long)
+	 (method static $bignum->string::string (::bignum ::int)
 	    "bgl_bignum_to_string")
 	 (method static $string->bignum::bignum (::string ::int)
 	    "bgl_string_to_bignum")


### PR DESCRIPTION
Fixes warnings such as this when building with LTO:
```
Clib/cwriter.c:20:14: warning: type of ‘bgl_bignum_to_string’ does not match original declaration [-Wlto-type-mismatch]
   20 | extern obj_t bgl_bignum_to_string(obj_t x, int radix);
      |              ^
objs/obj_u/Unsafe/bignumber.c:10609:32: note: type mismatch in parameter 2
10609 |         BGL_EXPORTED_DEF obj_t bgl_bignum_to_string(obj_t BgL_xz00_101,
      |                                ^
objs/obj_u/Unsafe/bignumber.c:10609:32: note: type ‘long int’ should match type ‘int’
objs/obj_u/Unsafe/bignumber.c:10609:32: note: ‘bgl_bignum_to_string’ was previously declared here
objs/obj_u/Unsafe/bignumber.c:10609:32: note: code may be misoptimized unless ‘-fno-strict-aliasing’ is used
```