### PR TITLE
Mmap enhancements

### DIFF
--- a/recette/Makefile
+++ b/recette/Makefile
@@ -58,7 +58,7 @@ ICOMMON		= vital bps bool list vector srfi4 struct print \
                   rgc_eval rgc hash module import1 import2 \
                   cfa2 cell hygiene wind dsssl sua peek callcc fringe \
                   unicode optim pregexp lalr system date process \
-                  mmap input_mmap_port weakptr crypto crc ssr
+                  mmap mmap_numeric input_mmap_port weakptr crypto crc ssr
 
 OCOMMON		= object object_sans \
                   object1 object1_sans \

--- a/recette/main.scm
+++ b/recette/main.scm
@@ -45,6 +45,7 @@
 	   input-port
            input-mmap-port
 	   mmap
+	   mmap-numeric
 	   read
 	   callcc
 	   fringe
@@ -305,6 +306,7 @@
 	  (if-module 'input-port test-input-port)
           (if-module 'input-mmap-port test-input-mmap-port)
 	  (if-module 'mmap test-mmap)
+	  (if-module 'mmap-numeric test-mmap-numeric)
 	  (if-module 'read test-read)
 	  (if *callcc?*
 	      (begin

--- a/recette/mmap_numeric.scm
+++ b/recette/mmap_numeric.scm
@@ -1,0 +1,141 @@
+;*=====================================================================*/
+;*    serrano/prgm/project/bigloo/recette/mmap_numeric.scm             */
+;*    -------------------------------------------------------------    */
+;*    Author      :  User                                              */
+;*    Creation    :  Sat Jul 18 2026                                   */
+;*    -------------------------------------------------------------    */
+;*    Test numeric mmap access functions                               */
+;*=====================================================================*/
+
+;*---------------------------------------------------------------------*/
+;*    The module                                                       */
+;*---------------------------------------------------------------------*/
+(module mmap-numeric
+   (import  (main "main.scm"))
+   (include "test.sch")
+   (export  (test-mmap-numeric)))
+
+;*---------------------------------------------------------------------*/
+;*    test-mmap-numeric ...                                            */
+;*---------------------------------------------------------------------*/
+(define (test-mmap-numeric)
+   (test-module "test-mmap-numeric" "mmap_numeric.scm")
+   
+   (let ((path "tmp_mmap_numeric.data"))
+      ;; Create a test file with known binary data
+      (with-output-to-file path
+	 (lambda ()
+	    ;; Write 200 bytes of zeros
+	    (let loop ((i 0))
+	       (when (<fx i 200)
+		  (write-byte 0)
+		  (loop (+fx i 1))))))
+      
+      (let ((mm (open-mmap path :read #t :write #t)))
+	 
+	 ;; Test 8-bit access
+	 (test "mmap-s8-set!.1" 
+	       (begin
+		  (mmap-s8-set! mm #e10 #s8:-42)
+		  (int8->fixnum (mmap-s8-ref mm #e10)))
+	       -42)
+	 
+	 (test "mmap-u8-set!.1"
+	       (begin
+		  (mmap-u8-set! mm #e11 #u8:100)
+		  (uint8->fixnum (mmap-u8-ref mm #e11)))
+	       100)
+	 
+	 ;; Test 16-bit access
+	 (test "mmap-u16-set!.1"
+	       (begin
+		  (mmap-u16-set! mm #e20 #u16:1234)
+		  (uint16->fixnum (mmap-u16-ref mm #e20)))
+	       1234)
+	 
+	 (test "mmap-s16-set!.1"
+	       (begin
+		  (mmap-s16-set! mm #e22 #s16:-1000)
+		  (int16->fixnum (mmap-s16-ref mm #e22)))
+	       -1000)
+	 
+	 ;; Test 32-bit access
+	 (test "mmap-u32-set!.1"
+	       (begin
+		  (mmap-u32-set! mm #e30 #u32:12345678)
+		  (uint32->fixnum (mmap-u32-ref mm #e30)))
+	       12345678)
+	 
+	 (test "mmap-s32-set!.1"
+	       (begin
+		  (mmap-s32-set! mm #e34 #s32:-100000)
+		  (int32->fixnum (mmap-s32-ref mm #e34)))
+	       -100000)
+	 
+	 ;; Test 64-bit access (use typed constants for comparison)
+	 (test "mmap-u64-set!.1"
+	       (begin
+		  (mmap-u64-set! mm #e40 #u64:1234567891234)
+		  (mmap-u64-ref mm #e40))
+	       #u64:1234567891234)
+	 
+	 (test "mmap-s64-set!.1"
+	       (begin
+		  (mmap-s64-set! mm #e48 #s64:-9876543210)
+		  (mmap-s64-ref mm #e48))
+	       #s64:-9876543210)
+	 
+	 ;; Test float access
+	 (test "mmap-f32-set!.1"
+	       (begin
+		  (mmap-f32-set! mm #e60 3.14159)
+		  (< (abs (- (mmap-f32-ref mm #e60) 3.14159)) 0.0001))
+	       #t)
+	 
+	 (test "mmap-f64-set!.1"
+	       (begin
+		  (mmap-f64-set! mm #e70 2.718281828459045)
+		  (< (abs (- (mmap-f64-ref mm #e70) 2.718281828459045)) 0.000000001))
+	       #t)
+	 
+	 ;; Test read position tracking
+	 (test "mmap-s32-ref.position"
+	       (begin
+		  (mmap-read-position-set! mm #e0)
+		  (mmap-s32-ref mm #e0)
+		  (mmap-read-position mm))
+	       #e4)
+	 
+	 (test "mmap-f64-ref.position"
+	       (begin
+		  (mmap-f64-ref mm #e10)
+		  (mmap-read-position mm))
+	       #e18)
+	 
+	 ;; Test write position tracking
+	 (test "mmap-u16-set!.position"
+	       (begin
+		  (mmap-write-position-set! mm #e0)
+		  (mmap-u16-set! mm #e0 #u16:42)
+		  (mmap-write-position mm))
+	       #e2)
+	 
+	 ;; Test bounds checking
+	 (test "mmap-s32-ref.bounds"
+	       (with-handler
+		  (lambda (e) #t)
+		  (mmap-s32-ref mm #e197)  ; Would need bytes 197-200, but only 0-199 exist
+		  #f)
+	       #t)
+	 
+	 (test "mmap-f64-set!.bounds"
+	       (with-handler
+		  (lambda (e) #t)
+		  (mmap-f64-set! mm #e195 1.0)  ; Would need bytes 195-202
+		  #f)
+	       #t)
+	 
+	 (close-mmap mm))
+      
+      ;; Clean up
+      (delete-file path)))

--- a/runtime/Clib/cmmap.c
+++ b/runtime/Clib/cmmap.c
@@ -245,3 +245,137 @@ bgl_mmap_nommap_set(obj_t mm, long i, unsigned char c) {
    }
 }
 #endif
+
+#if !defined(__GNUC__)
+/*---------------------------------------------------------------------*/
+/*    Numeric mmap access functions for non-GCC compilers             */
+/*---------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------*/
+/*    16-bit reads                                                     */
+/*---------------------------------------------------------------------*/
+BGL_RUNTIME_DEF int16_t
+bgl_mmap_s16_ref(obj_t mm, long i) {
+   int16_t result;
+   memcpy(&result, &BGL_MMAP(mm).map[i], sizeof(int16_t));
+   return result;
+}
+
+BGL_RUNTIME_DEF uint16_t
+bgl_mmap_u16_ref(obj_t mm, long i) {
+   uint16_t result;
+   memcpy(&result, &BGL_MMAP(mm).map[i], sizeof(uint16_t));
+   return result;
+}
+
+/*---------------------------------------------------------------------*/
+/*    32-bit reads                                                     */
+/*---------------------------------------------------------------------*/
+BGL_RUNTIME_DEF int32_t
+bgl_mmap_s32_ref(obj_t mm, long i) {
+   int32_t result;
+   memcpy(&result, &BGL_MMAP(mm).map[i], sizeof(int32_t));
+   return result;
+}
+
+BGL_RUNTIME_DEF uint32_t
+bgl_mmap_u32_ref(obj_t mm, long i) {
+   uint32_t result;
+   memcpy(&result, &BGL_MMAP(mm).map[i], sizeof(uint32_t));
+   return result;
+}
+
+/*---------------------------------------------------------------------*/
+/*    64-bit reads                                                     */
+/*---------------------------------------------------------------------*/
+BGL_RUNTIME_DEF int64_t
+bgl_mmap_s64_ref(obj_t mm, long i) {
+   int64_t result;
+   memcpy(&result, &BGL_MMAP(mm).map[i], sizeof(int64_t));
+   return result;
+}
+
+BGL_RUNTIME_DEF uint64_t
+bgl_mmap_u64_ref(obj_t mm, long i) {
+   uint64_t result;
+   memcpy(&result, &BGL_MMAP(mm).map[i], sizeof(uint64_t));
+   return result;
+}
+
+/*---------------------------------------------------------------------*/
+/*    Float reads                                                      */
+/*---------------------------------------------------------------------*/
+BGL_RUNTIME_DEF float
+bgl_mmap_f32_ref(obj_t mm, long i) {
+   float result;
+   memcpy(&result, &BGL_MMAP(mm).map[i], sizeof(float));
+   return result;
+}
+
+BGL_RUNTIME_DEF double
+bgl_mmap_f64_ref(obj_t mm, long i) {
+   double result;
+   memcpy(&result, &BGL_MMAP(mm).map[i], sizeof(double));
+   return result;
+}
+
+/*---------------------------------------------------------------------*/
+/*    16-bit writes                                                    */
+/*---------------------------------------------------------------------*/
+BGL_RUNTIME_DEF obj_t
+bgl_mmap_s16_set(obj_t mm, long i, int16_t val) {
+   memcpy(&BGL_MMAP(mm).map[i], &val, sizeof(int16_t));
+   return BUNSPEC;
+}
+
+BGL_RUNTIME_DEF obj_t
+bgl_mmap_u16_set(obj_t mm, long i, uint16_t val) {
+   memcpy(&BGL_MMAP(mm).map[i], &val, sizeof(uint16_t));
+   return BUNSPEC;
+}
+
+/*---------------------------------------------------------------------*/
+/*    32-bit writes                                                    */
+/*---------------------------------------------------------------------*/
+BGL_RUNTIME_DEF obj_t
+bgl_mmap_s32_set(obj_t mm, long i, int32_t val) {
+   memcpy(&BGL_MMAP(mm).map[i], &val, sizeof(int32_t));
+   return BUNSPEC;
+}
+
+BGL_RUNTIME_DEF obj_t
+bgl_mmap_u32_set(obj_t mm, long i, uint32_t val) {
+   memcpy(&BGL_MMAP(mm).map[i], &val, sizeof(uint32_t));
+   return BUNSPEC;
+}
+
+/*---------------------------------------------------------------------*/
+/*    64-bit writes                                                    */
+/*---------------------------------------------------------------------*/
+BGL_RUNTIME_DEF obj_t
+bgl_mmap_s64_set(obj_t mm, long i, int64_t val) {
+   memcpy(&BGL_MMAP(mm).map[i], &val, sizeof(int64_t));
+   return BUNSPEC;
+}
+
+BGL_RUNTIME_DEF obj_t
+bgl_mmap_u64_set(obj_t mm, long i, uint64_t val) {
+   memcpy(&BGL_MMAP(mm).map[i], &val, sizeof(uint64_t));
+   return BUNSPEC;
+}
+
+/*---------------------------------------------------------------------*/
+/*    Float writes                                                     */
+/*---------------------------------------------------------------------*/
+BGL_RUNTIME_DEF obj_t
+bgl_mmap_f32_set(obj_t mm, long i, float val) {
+   memcpy(&BGL_MMAP(mm).map[i], &val, sizeof(float));
+   return BUNSPEC;
+}
+
+BGL_RUNTIME_DEF obj_t
+bgl_mmap_f64_set(obj_t mm, long i, double val) {
+   memcpy(&BGL_MMAP(mm).map[i], &val, sizeof(double));
+   return BUNSPEC;
+}
+#endif /* !__GNUC__ */

--- a/runtime/Include/bigloo.h
+++ b/runtime/Include/bigloo.h
@@ -2039,6 +2039,138 @@ BGL_RUNTIME_DECL obj_t bgl_init_fx_procedure(obj_t, function_t, int, int);
 #endif
 
 /*---------------------------------------------------------------------*/
+/*    Alignment-safe mmap numeric access                               */
+/*---------------------------------------------------------------------*/
+/* 8-bit access doesn't need memcpy (always aligned) */
+#define BGL_MMAP_S8_REF(mm, i) ((int8_t)(BGL_MMAP(mm).map[i]))
+#define BGL_MMAP_U8_REF(mm, i) ((uint8_t)(BGL_MMAP(mm).map[i]))
+#define BGL_MMAP_S8_SET(mm, i, v) (BGL_MMAP(mm).map[i] = (int8_t)(v), BUNSPEC)
+#define BGL_MMAP_U8_SET(mm, i, v) (BGL_MMAP(mm).map[i] = (uint8_t)(v), BUNSPEC)
+
+#if defined(__GNUC__)
+/* GCC statement expressions allow efficient inline code with memcpy */
+
+#define BGL_MMAP_S16_REF(mm, i) ({ \
+   int16_t __result; \
+   memcpy(&__result, &BGL_MMAP(mm).map[i], sizeof(int16_t)); \
+   __result; })
+
+#define BGL_MMAP_U16_REF(mm, i) ({ \
+   uint16_t __result; \
+   memcpy(&__result, &BGL_MMAP(mm).map[i], sizeof(uint16_t)); \
+   __result; })
+
+#define BGL_MMAP_S32_REF(mm, i) ({ \
+   int32_t __result; \
+   memcpy(&__result, &BGL_MMAP(mm).map[i], sizeof(int32_t)); \
+   __result; })
+
+#define BGL_MMAP_U32_REF(mm, i) ({ \
+   uint32_t __result; \
+   memcpy(&__result, &BGL_MMAP(mm).map[i], sizeof(uint32_t)); \
+   __result; })
+
+#define BGL_MMAP_S64_REF(mm, i) ({ \
+   int64_t __result; \
+   memcpy(&__result, &BGL_MMAP(mm).map[i], sizeof(int64_t)); \
+   __result; })
+
+#define BGL_MMAP_U64_REF(mm, i) ({ \
+   uint64_t __result; \
+   memcpy(&__result, &BGL_MMAP(mm).map[i], sizeof(uint64_t)); \
+   __result; })
+
+#define BGL_MMAP_F32_REF(mm, i) ({ \
+   float __result; \
+   memcpy(&__result, &BGL_MMAP(mm).map[i], sizeof(float)); \
+   __result; })
+
+#define BGL_MMAP_F64_REF(mm, i) ({ \
+   double __result; \
+   memcpy(&__result, &BGL_MMAP(mm).map[i], sizeof(double)); \
+   __result; })
+
+/* Writes */
+#define BGL_MMAP_S16_SET(mm, i, v) ({ \
+   int16_t __val = (v); \
+   memcpy(&BGL_MMAP(mm).map[i], &__val, sizeof(int16_t)); \
+   BUNSPEC; })
+
+#define BGL_MMAP_U16_SET(mm, i, v) ({ \
+   uint16_t __val = (v); \
+   memcpy(&BGL_MMAP(mm).map[i], &__val, sizeof(uint16_t)); \
+   BUNSPEC; })
+
+#define BGL_MMAP_S32_SET(mm, i, v) ({ \
+   int32_t __val = (v); \
+   memcpy(&BGL_MMAP(mm).map[i], &__val, sizeof(int32_t)); \
+   BUNSPEC; })
+
+#define BGL_MMAP_U32_SET(mm, i, v) ({ \
+   uint32_t __val = (v); \
+   memcpy(&BGL_MMAP(mm).map[i], &__val, sizeof(uint32_t)); \
+   BUNSPEC; })
+
+#define BGL_MMAP_S64_SET(mm, i, v) ({ \
+   int64_t __val = (v); \
+   memcpy(&BGL_MMAP(mm).map[i], &__val, sizeof(int64_t)); \
+   BUNSPEC; })
+
+#define BGL_MMAP_U64_SET(mm, i, v) ({ \
+   uint64_t __val = (v); \
+   memcpy(&BGL_MMAP(mm).map[i], &__val, sizeof(uint64_t)); \
+   BUNSPEC; })
+
+#define BGL_MMAP_F32_SET(mm, i, v) ({ \
+   float __val = (v); \
+   memcpy(&BGL_MMAP(mm).map[i], &__val, sizeof(float)); \
+   BUNSPEC; })
+
+#define BGL_MMAP_F64_SET(mm, i, v) ({ \
+   double __val = (v); \
+   memcpy(&BGL_MMAP(mm).map[i], &__val, sizeof(double)); \
+   BUNSPEC; })
+
+#else
+/* For non-GCC compilers, use function calls */
+BGL_RUNTIME_DECL int16_t bgl_mmap_s16_ref(obj_t, long);
+BGL_RUNTIME_DECL uint16_t bgl_mmap_u16_ref(obj_t, long);
+BGL_RUNTIME_DECL int32_t bgl_mmap_s32_ref(obj_t, long);
+BGL_RUNTIME_DECL uint32_t bgl_mmap_u32_ref(obj_t, long);
+BGL_RUNTIME_DECL int64_t bgl_mmap_s64_ref(obj_t, long);
+BGL_RUNTIME_DECL uint64_t bgl_mmap_u64_ref(obj_t, long);
+BGL_RUNTIME_DECL float bgl_mmap_f32_ref(obj_t, long);
+BGL_RUNTIME_DECL double bgl_mmap_f64_ref(obj_t, long);
+
+BGL_RUNTIME_DECL obj_t bgl_mmap_s16_set(obj_t, long, int16_t);
+BGL_RUNTIME_DECL obj_t bgl_mmap_u16_set(obj_t, long, uint16_t);
+BGL_RUNTIME_DECL obj_t bgl_mmap_s32_set(obj_t, long, int32_t);
+BGL_RUNTIME_DECL obj_t bgl_mmap_u32_set(obj_t, long, uint32_t);
+BGL_RUNTIME_DECL obj_t bgl_mmap_s64_set(obj_t, long, int64_t);
+BGL_RUNTIME_DECL obj_t bgl_mmap_u64_set(obj_t, long, uint64_t);
+BGL_RUNTIME_DECL obj_t bgl_mmap_f32_set(obj_t, long, float);
+BGL_RUNTIME_DECL obj_t bgl_mmap_f64_set(obj_t, long, double);
+
+#define BGL_MMAP_S16_REF(mm, i) bgl_mmap_s16_ref(mm, i)
+#define BGL_MMAP_U16_REF(mm, i) bgl_mmap_u16_ref(mm, i)
+#define BGL_MMAP_S32_REF(mm, i) bgl_mmap_s32_ref(mm, i)
+#define BGL_MMAP_U32_REF(mm, i) bgl_mmap_u32_ref(mm, i)
+#define BGL_MMAP_S64_REF(mm, i) bgl_mmap_s64_ref(mm, i)
+#define BGL_MMAP_U64_REF(mm, i) bgl_mmap_u64_ref(mm, i)
+#define BGL_MMAP_F32_REF(mm, i) bgl_mmap_f32_ref(mm, i)
+#define BGL_MMAP_F64_REF(mm, i) bgl_mmap_f64_ref(mm, i)
+
+#define BGL_MMAP_S16_SET(mm, i, v) bgl_mmap_s16_set(mm, i, v)
+#define BGL_MMAP_U16_SET(mm, i, v) bgl_mmap_u16_set(mm, i, v)
+#define BGL_MMAP_S32_SET(mm, i, v) bgl_mmap_s32_set(mm, i, v)
+#define BGL_MMAP_U32_SET(mm, i, v) bgl_mmap_u32_set(mm, i, v)
+#define BGL_MMAP_S64_SET(mm, i, v) bgl_mmap_s64_set(mm, i, v)
+#define BGL_MMAP_U64_SET(mm, i, v) bgl_mmap_u64_set(mm, i, v)
+#define BGL_MMAP_F32_SET(mm, i, v) bgl_mmap_f32_set(mm, i, v)
+#define BGL_MMAP_F64_SET(mm, i, v) bgl_mmap_f64_set(mm, i, v)
+#endif
+
+/*---------------------------------------------------------------------*/
 /*    WEAKPTR                                                          */
 /*---------------------------------------------------------------------*/
 #define WEAKPTR(o) CREF(o)->weakptr

--- a/runtime/Jlib/foreign.java
+++ b/runtime/Jlib/foreign.java
@@ -7808,4 +7808,212 @@ public final class foreign
    public static void BGL_MMAP_WP_SET( mmap o, long i ) {
       o.wp = i;
    }
+
+   //////
+   // Numeric mmap access - 8-bit
+   //////
+   public static byte BGL_MMAP_S8_REF( mmap o, long i ) {
+      if( o.map == null ) {
+         return (byte)o.get( i );
+      } else {
+        return (byte) o.map.get( (int)i );
+      }
+   }
+   
+   public static byte BGL_MMAP_U8_REF( mmap o, long i ) {
+      if( o.map == null ) {
+        return (byte)o.get( i );
+      } else {
+        return (byte) o.map.get( (int)i );
+      }
+   }
+   
+   public static Object BGL_MMAP_S8_SET( mmap o, long i, byte v ) {
+      if( o.map == null ) {
+        o.put( i, v );
+      } else {
+        o.map.put( (int)i, v );
+      }
+      return o;
+   }
+   
+   public static Object BGL_MMAP_U8_SET( mmap o, long i, byte v ) {
+      if( o.map == null ) {
+         o.put( i, v);
+      } else {
+         o.map.put( (int)i, v );
+      }
+      return o;
+   }
+
+   //////
+   // Numeric mmap access - 16-bit
+   //////
+   public static short BGL_MMAP_S16_REF( mmap o, long i ) {
+      if( o.map == null ) {
+         // Fallback for non-mapped: read two bytes manually
+         int b0 = o.get( i ) & 0xff;
+         int b1 = o.get( i + 1 ) & 0xff;
+         return (short)((b1 << 8) | b0); // little-endian
+      } else {
+         return o.map.getShort( (int)i );
+      }
+   }
+   
+   public static short BGL_MMAP_U16_REF( mmap o, long i ) {
+      if( o.map == null ) {
+         int b0 = o.get( i ) & 0xff;
+         int b1 = o.get( i + 1 ) & 0xff;
+         return (short)(((b1 << 8) | b0) & 0xffff); // little-endian
+      } else {
+         return o.map.getShort( (int)i );
+      }
+   }
+   
+   public static Object BGL_MMAP_S16_SET( mmap o, long i, short v ) {
+      if( o.map == null ) {
+         o.put( i, (byte)(v & 0xff) );
+         o.put( i + 1, (byte)((v >> 8) & 0xff) );
+      } else {
+         o.map.putShort( (int)i, v );
+      }
+      return o;
+   }
+   
+   public static Object BGL_MMAP_U16_SET( mmap o, long i, short v ) {
+      if( o.map == null ) {
+         o.put( i, (byte)(v & 0xff) );
+         o.put( i + 1, (byte)((v >> 8) & 0xff) );
+      } else {
+         o.map.putShort( (int)i, (short)v );
+      }
+      return o;
+   }
+
+   //////
+   // Numeric mmap access - 32-bit
+   //////
+   public static int BGL_MMAP_S32_REF( mmap o, long i ) {
+      if( o.map == null ) {
+         int b0 = o.get( i ) & 0xff;
+         int b1 = o.get( i + 1 ) & 0xff;
+         int b2 = o.get( i + 2 ) & 0xff;
+         int b3 = o.get( i + 3 ) & 0xff;
+         return (b3 << 24) | (b2 << 16) | (b1 << 8) | b0; // little-endian
+      } else {
+         return o.map.getInt( (int)i );
+      }
+   }
+   
+   public static int BGL_MMAP_U32_REF( mmap o, long i ) {
+      if( o.map == null ) {
+         long b0 = o.get( i ) & 0xffL;
+         long b1 = o.get( i + 1 ) & 0xffL;
+         long b2 = o.get( i + 2 ) & 0xffL;
+         long b3 = o.get( i + 3 ) & 0xffL;
+         return (int)((b3 << 24) | (b2 << 16) | (b1 << 8) | b0); // little-endian
+      } else {
+         return o.map.getInt( (int)i );
+      }
+   }
+   
+   public static Object BGL_MMAP_S32_SET( mmap o, long i, int v ) {
+      if( o.map == null ) {
+         o.put( i, (byte)(v & 0xff) );
+         o.put( i + 1, (byte)((v >> 8) & 0xff) );
+         o.put( i + 2, (byte)((v >> 16) & 0xff) );
+         o.put( i + 3, (byte)((v >> 24) & 0xff) );
+      } else {
+         o.map.putInt( (int)i, v );
+      }
+      return o;
+   }
+   
+   public static Object BGL_MMAP_U32_SET( mmap o, long i, int v ) {
+      if( o.map == null ) {
+         o.put( i, (byte)(v & 0xff) );
+         o.put( i + 1, (byte)((v >> 8) & 0xff) );
+         o.put( i + 2, (byte)((v >> 16) & 0xff) );
+         o.put( i + 3, (byte)((v >> 24) & 0xff) );
+      } else {
+         o.map.putInt( (int)i, (int)v );
+      }
+      return o;
+   }
+
+   //////
+   // Numeric mmap access - 64-bit
+   //////
+   public static long BGL_MMAP_S64_REF( mmap o, long i ) {
+      if( o.map == null ) {
+         long result = 0;
+         for( int j = 0; j < 8; j++ ) {
+            result |= ((long)(o.get( i + j ) & 0xff)) << (j * 8);
+         }
+         return result; // little-endian
+      } else {
+         return o.map.getLong( (int)i );
+      }
+   }
+   
+   public static long BGL_MMAP_U64_REF( mmap o, long i ) {
+      // In Java, long is signed, so u64 and s64 are the same
+      return BGL_MMAP_S64_REF( o, i );
+   }
+   
+   public static Object BGL_MMAP_S64_SET( mmap o, long i, long v ) {
+      if( o.map == null ) {
+         for( int j = 0; j < 8; j++ ) {
+            o.put( i + j, (byte)((v >> (j * 8)) & 0xff) );
+         }
+      } else {
+         o.map.putLong( (int)i, v );
+      }
+      return o;
+   }
+   
+   public static Object BGL_MMAP_U64_SET( mmap o, long i, long v ) {
+      return BGL_MMAP_S64_SET( o, i, v );
+   }
+
+   //////
+   // Numeric mmap access - floats
+   //////
+   public static float BGL_MMAP_F32_REF( mmap o, long i ) {
+      if( o.map == null ) {
+         int bits = BGL_MMAP_S32_REF( o, i );
+         return Float.intBitsToFloat( bits );
+      } else {
+         return o.map.getFloat( (int)i );
+      }
+   }
+   
+   public static double BGL_MMAP_F64_REF( mmap o, long i ) {
+      if( o.map == null ) {
+         long bits = BGL_MMAP_S64_REF( o, i );
+         return Double.longBitsToDouble( bits );
+      } else {
+         return o.map.getDouble( (int)i );
+      }
+   }
+   
+   public static Object BGL_MMAP_F32_SET( mmap o, long i, float v ) {
+      if( o.map == null ) {
+         int bits = Float.floatToRawIntBits( v );
+         BGL_MMAP_S32_SET( o, i, bits );
+      } else {
+         o.map.putFloat( (int)i, v );
+      }
+      return o;
+   }
+   
+   public static Object BGL_MMAP_F64_SET( mmap o, long i, double v ) {
+      if( o.map == null ) {
+         long bits = Double.doubleToRawLongBits( v );
+         BGL_MMAP_S64_SET( o, i, bits );
+      } else {
+         o.map.putDouble( (int)i, v );
+      }
+      return o;
+   }
 }

--- a/runtime/Jlib/mmap.java
+++ b/runtime/Jlib/mmap.java
@@ -54,6 +54,8 @@ public class mmap extends obj {
 	 }
 	 name = file;
 	 
+	 // Set byte order to little-endian for numeric access
+	 map.order( ByteOrder.LITTLE_ENDIAN );
 	 map.load();
 	 
 	 rp = 0; wp = 0;

--- a/runtime/Llib/mmap.scm
+++ b/runtime/Llib/mmap.scm
@@ -56,7 +56,37 @@
 	    (macro $mmap-rp-set!::void (::mmap ::elong) "BGL_MMAP_RP_SET")
 	    (macro $mmap-wp::elong (::mmap) "BGL_MMAP_WP_GET")
 	    (macro $mmap-wp-set!::void (::mmap ::elong) "BGL_MMAP_WP_SET")
-	    (macro $mmap-bound-check?::bool (::elong ::elong) "BOUND_CHECK"))
+	    (macro $mmap-bound-check?::bool (::elong ::elong) "BOUND_CHECK")
+	    
+	    ;; Numeric mmap access - 8-bit
+	    (macro $mmap-s8-ref::int8 (::mmap ::elong) "BGL_MMAP_S8_REF")
+	    (macro $mmap-u8-ref::uint8 (::mmap ::elong) "BGL_MMAP_U8_REF")
+	    (macro $mmap-s8-set!::obj (::mmap ::elong ::int8) "BGL_MMAP_S8_SET")
+	    (macro $mmap-u8-set!::obj (::mmap ::elong ::uint8) "BGL_MMAP_U8_SET")
+	    
+	    ;; Numeric mmap access - 16-bit
+	    (macro $mmap-s16-ref::int16 (::mmap ::elong) "BGL_MMAP_S16_REF")
+	    (macro $mmap-u16-ref::uint16 (::mmap ::elong) "BGL_MMAP_U16_REF")
+	    (macro $mmap-s16-set!::obj (::mmap ::elong ::int16) "BGL_MMAP_S16_SET")
+	    (macro $mmap-u16-set!::obj (::mmap ::elong ::uint16) "BGL_MMAP_U16_SET")
+	    
+	    ;; Numeric mmap access - 32-bit
+	    (macro $mmap-s32-ref::int32 (::mmap ::elong) "BGL_MMAP_S32_REF")
+	    (macro $mmap-u32-ref::uint32 (::mmap ::elong) "BGL_MMAP_U32_REF")
+	    (macro $mmap-s32-set!::obj (::mmap ::elong ::int32) "BGL_MMAP_S32_SET")
+	    (macro $mmap-u32-set!::obj (::mmap ::elong ::uint32) "BGL_MMAP_U32_SET")
+	    
+	    ;; Numeric mmap access - 64-bit
+	    (macro $mmap-s64-ref::int64 (::mmap ::elong) "BGL_MMAP_S64_REF")
+	    (macro $mmap-u64-ref::uint64 (::mmap ::elong) "BGL_MMAP_U64_REF")
+	    (macro $mmap-s64-set!::obj (::mmap ::elong ::int64) "BGL_MMAP_S64_SET")
+	    (macro $mmap-u64-set!::obj (::mmap ::elong ::uint64) "BGL_MMAP_U64_SET")
+	    
+	    ;; Numeric mmap access - floats
+	    (macro $mmap-f32-ref::float (::mmap ::elong) "BGL_MMAP_F32_REF")
+	    (macro $mmap-f64-ref::double (::mmap ::elong) "BGL_MMAP_F64_REF")
+	    (macro $mmap-f32-set!::obj (::mmap ::elong ::float) "BGL_MMAP_F32_SET")
+	    (macro $mmap-f64-set!::obj (::mmap ::elong ::double) "BGL_MMAP_F64_SET"))
    
    (java    (class foreign
 	       (method static $mmap?::bool (::obj)
@@ -86,7 +116,57 @@
 	       (method static $mmap-wp-set!::void (::mmap ::elong)
 		  "BGL_MMAP_WP_SET")	
 	       (method static $mmap-bound-check?::bool (::elong ::elong)
-		  "BOUND_CHECK")))
+		  "BOUND_CHECK")
+	       
+	       ;; Numeric mmap access - 8-bit
+	       (method static $mmap-s8-ref::int8 (::mmap ::elong)
+		  "BGL_MMAP_S8_REF")
+	       (method static $mmap-u8-ref::uint8 (::mmap ::elong)
+		  "BGL_MMAP_U8_REF")
+	       (method static $mmap-s8-set!::obj (::mmap ::elong ::int8)
+		  "BGL_MMAP_S8_SET")
+	       (method static $mmap-u8-set!::obj (::mmap ::elong ::uint8)
+		  "BGL_MMAP_U8_SET")
+	       
+	       ;; Numeric mmap access - 16-bit
+	       (method static $mmap-s16-ref::int16 (::mmap ::elong)
+		  "BGL_MMAP_S16_REF")
+	       (method static $mmap-u16-ref::uint16 (::mmap ::elong)
+		  "BGL_MMAP_U16_REF")
+	       (method static $mmap-s16-set!::obj (::mmap ::elong ::int16)
+		  "BGL_MMAP_S16_SET")
+	       (method static $mmap-u16-set!::obj (::mmap ::elong ::uint16)
+		  "BGL_MMAP_U16_SET")
+	       
+	       ;; Numeric mmap access - 32-bit
+	       (method static $mmap-s32-ref::int32 (::mmap ::elong)
+		  "BGL_MMAP_S32_REF")
+	       (method static $mmap-u32-ref::uint32 (::mmap ::elong)
+		  "BGL_MMAP_U32_REF")
+	       (method static $mmap-s32-set!::obj (::mmap ::elong ::int32)
+		  "BGL_MMAP_S32_SET")
+	       (method static $mmap-u32-set!::obj (::mmap ::elong ::uint32)
+		  "BGL_MMAP_U32_SET")
+	       
+	       ;; Numeric mmap access - 64-bit
+	       (method static $mmap-s64-ref::int64 (::mmap ::elong)
+		  "BGL_MMAP_S64_REF")
+	       (method static $mmap-u64-ref::uint64 (::mmap ::elong)
+		  "BGL_MMAP_U64_REF")
+	       (method static $mmap-s64-set!::obj (::mmap ::elong ::int64)
+		  "BGL_MMAP_S64_SET")
+	       (method static $mmap-u64-set!::obj (::mmap ::elong ::uint64)
+		  "BGL_MMAP_U64_SET")
+	       
+	       ;; Numeric mmap access - floats
+	       (method static $mmap-f32-ref::float (::mmap ::elong)
+		  "BGL_MMAP_F32_REF")
+	       (method static $mmap-f64-ref::double (::mmap ::elong)
+		  "BGL_MMAP_F64_REF")
+	       (method static $mmap-f32-set!::obj (::mmap ::elong ::float)
+		  "BGL_MMAP_F32_SET")
+	       (method static $mmap-f64-set!::obj (::mmap ::elong ::double)
+		  "BGL_MMAP_F64_SET")))
    
    (export  (inline mmap?::bool ::obj)
 	    (open-mmap::mmap ::bstring #!key (read #t) (write #t))
@@ -109,7 +189,37 @@
 	    (inline mmap-get-char::uchar ::mmap)
 	    (inline mmap-put-char! ::mmap ::uchar)
 	    (inline mmap-get-string::bstring ::mmap ::elong)
-	    (inline mmap-put-string! ::mmap ::bstring)))
+	    (inline mmap-put-string! ::mmap ::bstring)
+	    
+	    ;; Numeric access - 8-bit
+	    (inline mmap-s8-ref::int8 ::mmap ::elong)
+	    (inline mmap-u8-ref::uint8 ::mmap ::elong)
+	    (inline mmap-s8-set!::obj ::mmap ::elong ::int8)
+	    (inline mmap-u8-set!::obj ::mmap ::elong ::uint8)
+	    
+	    ;; Numeric access - 16-bit
+	    (inline mmap-s16-ref::int16 ::mmap ::elong)
+	    (inline mmap-u16-ref::uint16 ::mmap ::elong)
+	    (inline mmap-s16-set!::obj ::mmap ::elong ::int16)
+	    (inline mmap-u16-set!::obj ::mmap ::elong ::uint16)
+	    
+	    ;; Numeric access - 32-bit
+	    (inline mmap-s32-ref::int32 ::mmap ::elong)
+	    (inline mmap-u32-ref::uint32 ::mmap ::elong)
+	    (inline mmap-s32-set!::obj ::mmap ::elong ::int32)
+	    (inline mmap-u32-set!::obj ::mmap ::elong ::uint32)
+	    
+	    ;; Numeric access - 64-bit
+	    (inline mmap-s64-ref::int64 ::mmap ::elong)
+	    (inline mmap-u64-ref::uint64 ::mmap ::elong)
+	    (inline mmap-s64-set!::obj ::mmap ::elong ::int64)
+	    (inline mmap-u64-set!::obj ::mmap ::elong ::uint64)
+	    
+	    ;; Numeric access - floats
+	    (inline mmap-f32-ref::float ::mmap ::elong)
+	    (inline mmap-f64-ref::double ::mmap ::elong)
+	    (inline mmap-f32-set!::obj ::mmap ::elong ::float)
+	    (inline mmap-f64-set!::obj ::mmap ::elong ::double)))
  
 ;*---------------------------------------------------------------------*/
 ;*    mmap? ...                                                        */
@@ -306,3 +416,248 @@
 ;*---------------------------------------------------------------------*/
 (define-inline (mmap-put-string! mm::mmap s)
    (mmap-substring-set! mm ($mmap-wp mm) s))
+
+;*---------------------------------------------------------------------*/
+;*    Numeric mmap access - 8-bit                                      */
+;*---------------------------------------------------------------------*/
+(define-inline (mmap-s8-ref mm::mmap i::elong)
+   (if ($mmap-bound-check? i (mmap-length mm))
+       (let ((val ($mmap-s8-ref mm i)))
+	  (mmap-read-position-set! mm (+elong i #e1))
+	  val)
+       (error 'mmap-s8-ref
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e1))
+			     "]")
+	      i)))
+
+(define-inline (mmap-u8-ref mm::mmap i::elong)
+   (if ($mmap-bound-check? i (mmap-length mm))
+       (let ((val ($mmap-u8-ref mm i)))
+	  (mmap-read-position-set! mm (+elong i #e1))
+	  val)
+       (error 'mmap-u8-ref
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e1))
+			     "]")
+	      i)))
+
+(define-inline (mmap-s8-set! mm::mmap i::elong val::int8)
+   (if ($mmap-bound-check? i (mmap-length mm))
+       (begin
+	  ($mmap-s8-set! mm i val)
+	  (mmap-write-position-set! mm (+elong i #e1))
+	  mm)
+       (error 'mmap-s8-set!
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e1))
+			     "]")
+	      i)))
+
+(define-inline (mmap-u8-set! mm::mmap i::elong val::uint8)
+   (if ($mmap-bound-check? i (mmap-length mm))
+       (begin
+	  ($mmap-u8-set! mm i val)
+	  (mmap-write-position-set! mm (+elong i #e1))
+	  mm)
+       (error 'mmap-u8-set!
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e1))
+			     "]")
+	      i)))
+
+;*---------------------------------------------------------------------*/
+;*    Numeric mmap access - 16-bit                                     */
+;*---------------------------------------------------------------------*/
+(define-inline (mmap-s16-ref mm::mmap i::elong)
+   (if ($mmap-bound-check? (+elong i #e1) (mmap-length mm))
+       (let ((val ($mmap-s16-ref mm i)))
+	  (mmap-read-position-set! mm (+elong i #e2))
+	  val)
+       (error 'mmap-s16-ref
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e2))
+			     "]")
+	      i)))
+
+(define-inline (mmap-u16-ref mm::mmap i::elong)
+   (if ($mmap-bound-check? (+elong i #e1) (mmap-length mm))
+       (let ((val ($mmap-u16-ref mm i)))
+	  (mmap-read-position-set! mm (+elong i #e2))
+	  val)
+       (error 'mmap-u16-ref
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e2))
+			     "]")
+	      i)))
+
+(define-inline (mmap-s16-set! mm::mmap i::elong val::int16)
+   (if ($mmap-bound-check? (+elong i #e1) (mmap-length mm))
+       (begin
+	  ($mmap-s16-set! mm i val)
+	  (mmap-write-position-set! mm (+elong i #e2))
+	  mm)
+       (error 'mmap-s16-set!
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e2))
+			     "]")
+	      i)))
+
+(define-inline (mmap-u16-set! mm::mmap i::elong val::uint16)
+   (if ($mmap-bound-check? (+elong i #e1) (mmap-length mm))
+       (begin
+	  ($mmap-u16-set! mm i val)
+	  (mmap-write-position-set! mm (+elong i #e2))
+	  mm)
+       (error 'mmap-u16-set!
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e2))
+			     "]")
+	      i)))
+
+;*---------------------------------------------------------------------*/
+;*    Numeric mmap access - 32-bit                                     */
+;*---------------------------------------------------------------------*/
+(define-inline (mmap-s32-ref mm::mmap i::elong)
+   (if ($mmap-bound-check? (+elong i #e3) (mmap-length mm))
+       (let ((val ($mmap-s32-ref mm i)))
+	  (mmap-read-position-set! mm (+elong i #e4))
+	  val)
+       (error 'mmap-s32-ref
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e4))
+			     "]")
+	      i)))
+
+(define-inline (mmap-u32-ref mm::mmap i::elong)
+   (if ($mmap-bound-check? (+elong i #e3) (mmap-length mm))
+       (let ((val ($mmap-u32-ref mm i)))
+	  (mmap-read-position-set! mm (+elong i #e4))
+	  val)
+       (error 'mmap-u32-ref
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e4))
+			     "]")
+	      i)))
+
+(define-inline (mmap-s32-set! mm::mmap i::elong val::int32)
+   (if ($mmap-bound-check? (+elong i #e3) (mmap-length mm))
+       (begin
+	  ($mmap-s32-set! mm i val)
+	  (mmap-write-position-set! mm (+elong i #e4))
+	  mm)
+       (error 'mmap-s32-set!
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e4))
+			     "]")
+	      i)))
+
+(define-inline (mmap-u32-set! mm::mmap i::elong val::uint32)
+   (if ($mmap-bound-check? (+elong i #e3) (mmap-length mm))
+       (begin
+	  ($mmap-u32-set! mm i val)
+	  (mmap-write-position-set! mm (+elong i #e4))
+	  mm)
+       (error 'mmap-u32-set!
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e4))
+			     "]")
+	      i)))
+
+;*---------------------------------------------------------------------*/
+;*    Numeric mmap access - 64-bit                                     */
+;*---------------------------------------------------------------------*/
+(define-inline (mmap-s64-ref mm::mmap i::elong)
+   (if ($mmap-bound-check? (+elong i #e7) (mmap-length mm))
+       (let ((val ($mmap-s64-ref mm i)))
+	  (mmap-read-position-set! mm (+elong i #e8))
+	  val)
+       (error 'mmap-s64-ref
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e8))
+			     "]")
+	      i)))
+
+(define-inline (mmap-u64-ref mm::mmap i::elong)
+   (if ($mmap-bound-check? (+elong i #e7) (mmap-length mm))
+       (let ((val ($mmap-u64-ref mm i)))
+	  (mmap-read-position-set! mm (+elong i #e8))
+	  val)
+       (error 'mmap-u64-ref
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e8))
+			     "]")
+	      i)))
+
+(define-inline (mmap-s64-set! mm::mmap i::elong val::int64)
+   (if ($mmap-bound-check? (+elong i #e7) (mmap-length mm))
+       (begin
+	  ($mmap-s64-set! mm i val)
+	  (mmap-write-position-set! mm (+elong i #e8))
+	  mm)
+       (error 'mmap-s64-set!
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e8))
+			     "]")
+	      i)))
+
+(define-inline (mmap-u64-set! mm::mmap i::elong val::uint64)
+   (if ($mmap-bound-check? (+elong i #e7) (mmap-length mm))
+       (begin
+	  ($mmap-u64-set! mm i val)
+	  (mmap-write-position-set! mm (+elong i #e8))
+	  mm)
+       (error 'mmap-u64-set!
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e8))
+			     "]")
+	      i)))
+
+;*---------------------------------------------------------------------*/
+;*    Numeric mmap access - floats                                     */
+;*---------------------------------------------------------------------*/
+(define-inline (mmap-f32-ref mm::mmap i::elong)
+   (if ($mmap-bound-check? (+elong i #e3) (mmap-length mm))
+       (let ((val ($mmap-f32-ref mm i)))
+	  (mmap-read-position-set! mm (+elong i #e4))
+	  val)
+       (error 'mmap-f32-ref
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e4))
+			     "]")
+	      i)))
+
+(define-inline (mmap-f64-ref mm::mmap i::elong)
+   (if ($mmap-bound-check? (+elong i #e7) (mmap-length mm))
+       (let ((val ($mmap-f64-ref mm i)))
+	  (mmap-read-position-set! mm (+elong i #e8))
+	  val)
+       (error 'mmap-f64-ref
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e8))
+			     "]")
+	      i)))
+
+(define-inline (mmap-f32-set! mm::mmap i::elong val::float)
+   (if ($mmap-bound-check? (+elong i #e3) (mmap-length mm))
+       (begin
+	  ($mmap-f32-set! mm i val)
+	  (mmap-write-position-set! mm (+elong i #e4))
+	  mm)
+       (error 'mmap-f32-set!
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e4))
+			     "]")
+	      i)))
+
+(define-inline (mmap-f64-set! mm::mmap i::elong val::double)
+   (if ($mmap-bound-check? (+elong i #e7) (mmap-length mm))
+       (begin
+	  ($mmap-f64-set! mm i val)
+	  (mmap-write-position-set! mm (+elong i #e8))
+	  mm)
+       (error 'mmap-f64-set!
+	      (string-append "index out of range [0.."
+			     (number->string (-elong (mmap-length mm) #e8))
+			     "]")
+	      i)))


### PR DESCRIPTION
Add support for numeric accessors for mmap

In addition to the char access currently supplied we add accessors for
int8, uint8, int16, uint16, int32, unit32, int64, uint64, float, and
double. All are alignment safe. The assume little-endian byte-order.
